### PR TITLE
개인 정보 및 전적 조회 API 구현

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+This repository is `WordOnlineMatching`, the lobby and matchmaking server for Word Online. Source code lives under `src/main/java/com/wordonline/matching` and `src/main/kotlin/com/wordonline/matching`; both Java and Kotlin are active. Feature packages include `auth`, `matching`, `session`, `server`, `deck`, `magic`, `quest`, `adventure`, `data`, `decoration`, `deploy`, and `global`. Tests are in `src/test/java`. Runtime configuration and SQL helpers are in `src/main/resources`, while API notes are in `docs/api`.
+
+Related repositories:
+- `Apptive-Game-Team/WordOnlineServer`: actual game session server.
+- `Apptive-Game-Team/WordOnlineClient`: Unity client consuming these APIs.
+- `Apptive-Game-Team/AccountServer`: account/member service used by `AccountClient`.
+- `Apptive-Game-Team/WordOnlineDatabase`: database migration source of truth.
+
+## Build, Test, and Development Commands
+
+- `./gradlew compileJava compileKotlin`: compile Java and Kotlin sources.
+- `./gradlew test`: run JUnit 5 tests, including WebFlux and Reactor tests.
+- `./gradlew bootRun`: run the Spring Boot app locally.
+- `./gradlew bootJar`: create the deployable Spring Boot jar.
+
+Local runs require environment variables from `application.yml`: `PORT`, `DATABASE_URL`, `DATABASE_USERNAME`, `DATABASE_PASSWORD`, `REDIS_HOST`, `REDIS_PORT`, `ACCOUNT_SERVER_URL`, `JWT_PRIVATE_KEY`, and `JWT_PUBLIC_KEY`. For schema questions, inspect `../database/migration` first; do not rely on this repo's `src/main/resources/schema.sql` as authoritative.
+
+## Coding Style & Naming Conventions
+
+Use package-by-feature organization. Java uses Lombok where already established; Kotlin is used for newer matching/deploy code. Keep controllers thin, business logic in services, and database access in repositories. Prefer reactive types (`Mono`, `Flux`) in Java and coroutine interop in Kotlin. Use 4-space indentation and descriptive DTO names such as `MatchedInfoDto` or `DeployStatusResponse`.
+
+## Testing Guidelines
+
+Tests use JUnit 5, Spring Boot Test, Spring Security Test, and Reactor Test. Name tests by behavior; existing tests include Korean display-style method names. Add focused tests for controller response shapes, service branching, and repository queries when behavior changes. Run `./gradlew test` before handing off.
+
+## Commit & Pull Request Guidelines
+
+Recent history uses short conventional-style prefixes such as `feat:`, `fix:`, and `refactor(...)`, often with linked issue numbers like `(#36)`. Keep commits scoped to one concern. PRs should describe behavior changes, link the GitHub issue, mention affected endpoints, and note any required database migration or client/game-server/account-server coordination.
+
+## Security & Configuration Tips
+
+Do not commit secrets or local `.env` values. JWT keys, database credentials, Redis settings, and account server URLs must remain environment-driven. Database schema changes belong in `WordOnlineDatabase`; treat lobby-server `schema.sql` as stale/local reference material unless verified against the database repo.

--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -1,0 +1,11 @@
+services:
+  redis:
+    image: redis:latest
+    container_name: ac-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
+volumes:
+    redis_data:

--- a/src/main/java/com/wordonline/matching/auth/controller/UserController.java
+++ b/src/main/java/com/wordonline/matching/auth/controller/UserController.java
@@ -2,6 +2,8 @@ package com.wordonline.matching.auth.controller;
 
 import java.util.Map;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -11,8 +13,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.wordonline.matching.auth.dto.UserResponseDto;
+import com.wordonline.matching.auth.dto.UserStatisticsGamesResponseDto;
+import com.wordonline.matching.auth.dto.UserStatisticsOverviewResponseDto;
 import com.wordonline.matching.auth.service.UserId;
 import com.wordonline.matching.auth.service.UserService;
+import com.wordonline.matching.auth.service.UserStatisticsService;
 import com.wordonline.matching.matching.dto.MatchedInfoDto;
 import com.wordonline.matching.quest.dto.QuestCheckResponseDto;
 import com.wordonline.matching.quest.service.QuestService;
@@ -29,6 +34,7 @@ import reactor.core.publisher.Mono;
 public class UserController {
 
     private final UserService userService;
+    private final UserStatisticsService userStatisticsService;
     private final LegacyGameMatchService gameMatchService;
     private final QuestService questService;
 
@@ -50,6 +56,21 @@ public class UserController {
     ) {
         return userService.getStatus(userId)
                 .map(status -> Map.of("status", status.name()));
+    }
+
+    @GetMapping("/mine/statistics/overview")
+    public Mono<UserStatisticsOverviewResponseDto> getMyStatisticsOverview(
+            @UserId Long userId
+    ) {
+        return userStatisticsService.getOverview(userId);
+    }
+
+    @GetMapping("/mine/statistics/games")
+    public Mono<UserStatisticsGamesResponseDto> getMyStatisticsGames(
+            @UserId Long userId,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        return userStatisticsService.getGames(userId, pageable);
     }
 
     @GetMapping("/mine/match-info")

--- a/src/main/java/com/wordonline/matching/auth/dto/UserGameRecordResponseDto.java
+++ b/src/main/java/com/wordonline/matching/auth/dto/UserGameRecordResponseDto.java
@@ -1,0 +1,7 @@
+package com.wordonline.matching.auth.dto;
+
+public record UserGameRecordResponseDto(
+        Long opponentId,
+        String result
+) {
+}

--- a/src/main/java/com/wordonline/matching/auth/dto/UserResponseDto.java
+++ b/src/main/java/com/wordonline/matching/auth/dto/UserResponseDto.java
@@ -2,9 +2,9 @@ package com.wordonline.matching.auth.dto;
 
 import com.wordonline.matching.auth.domain.User;
 
-public record UserResponseDto(Long id, Long selectedDeckId) {
+public record UserResponseDto(Long id, Long selectedDeckId, Long mmr) {
 
     public UserResponseDto(User user) {
-        this(user.getId(), user.getSelectedDeckId());
+        this(user.getId(), user.getSelectedDeckId(), user.getMmr() != null ? user.getMmr() : 0L);
     }
 }

--- a/src/main/java/com/wordonline/matching/auth/dto/UserStatisticsGamesResponseDto.java
+++ b/src/main/java/com/wordonline/matching/auth/dto/UserStatisticsGamesResponseDto.java
@@ -1,0 +1,6 @@
+package com.wordonline.matching.auth.dto;
+
+import java.util.List;
+
+public record UserStatisticsGamesResponseDto(List<UserGameRecordResponseDto> games) {
+}

--- a/src/main/java/com/wordonline/matching/auth/dto/UserStatisticsOverviewResponseDto.java
+++ b/src/main/java/com/wordonline/matching/auth/dto/UserStatisticsOverviewResponseDto.java
@@ -1,0 +1,7 @@
+package com.wordonline.matching.auth.dto;
+
+public record UserStatisticsOverviewResponseDto(
+        Long totalGameNum,
+        Long totalWinNum
+) {
+}

--- a/src/main/java/com/wordonline/matching/auth/repository/UserStatisticsRepository.java
+++ b/src/main/java/com/wordonline/matching/auth/repository/UserStatisticsRepository.java
@@ -1,0 +1,62 @@
+package com.wordonline.matching.auth.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.stereotype.Repository;
+
+import com.wordonline.matching.auth.dto.UserGameRecordResponseDto;
+import com.wordonline.matching.auth.dto.UserStatisticsOverviewResponseDto;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Repository
+@RequiredArgsConstructor
+public class UserStatisticsRepository {
+
+    private final DatabaseClient databaseClient;
+
+    public Mono<UserStatisticsOverviewResponseDto> findOverviewByUserId(Long userId) {
+        return databaseClient.sql("""
+                        SELECT
+                            COUNT(*) AS total_game_num,
+                            COALESCE(SUM(CASE WHEN win_user_id = :userId THEN 1 ELSE 0 END), 0) AS total_win_num
+                        FROM statistic_games
+                        WHERE win_user_id = :userId OR loss_user_id = :userId
+                        """)
+                .bind("userId", userId)
+                .map((row, metadata) -> new UserStatisticsOverviewResponseDto(
+                        row.get("total_game_num", Number.class).longValue(),
+                        row.get("total_win_num", Number.class).longValue()))
+                .one();
+    }
+
+    public Flux<UserGameRecordResponseDto> findGamesByUserId(Long userId, Pageable pageable) {
+        int limit = pageable.isPaged() ? pageable.getPageSize() : Integer.MAX_VALUE;
+        long offset = pageable.isPaged() ? pageable.getOffset() : 0L;
+
+        return databaseClient.sql("""
+                        SELECT
+                            CASE
+                                WHEN win_user_id = :userId THEN loss_user_id
+                                ELSE win_user_id
+                            END AS opponent_id,
+                            CASE
+                                WHEN win_user_id = :userId THEN 'win'
+                                ELSE 'lose'
+                            END AS result
+                        FROM statistic_games
+                        WHERE win_user_id = :userId OR loss_user_id = :userId
+                        ORDER BY created_at DESC, id DESC
+                        LIMIT :limit OFFSET :offset
+                        """)
+                .bind("userId", userId)
+                .bind("limit", limit)
+                .bind("offset", offset)
+                .map((row, metadata) -> new UserGameRecordResponseDto(
+                        row.get("opponent_id", Long.class),
+                        row.get("result", String.class)))
+                .all();
+    }
+}

--- a/src/main/java/com/wordonline/matching/auth/service/UserStatisticsService.java
+++ b/src/main/java/com/wordonline/matching/auth/service/UserStatisticsService.java
@@ -1,0 +1,30 @@
+package com.wordonline.matching.auth.service;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.wordonline.matching.auth.dto.UserStatisticsGamesResponseDto;
+import com.wordonline.matching.auth.dto.UserStatisticsOverviewResponseDto;
+import com.wordonline.matching.auth.repository.UserStatisticsRepository;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserStatisticsService {
+
+    private final UserStatisticsRepository userStatisticsRepository;
+
+    public Mono<UserStatisticsOverviewResponseDto> getOverview(Long userId) {
+        return userStatisticsRepository.findOverviewByUserId(userId);
+    }
+
+    public Mono<UserStatisticsGamesResponseDto> getGames(Long userId, Pageable pageable) {
+        return userStatisticsRepository.findGamesByUserId(userId, pageable)
+                .collectList()
+                .map(UserStatisticsGamesResponseDto::new);
+    }
+}

--- a/src/main/java/com/wordonline/matching/global/config/PageableWebFluxConfig.java
+++ b/src/main/java/com/wordonline/matching/global/config/PageableWebFluxConfig.java
@@ -1,0 +1,19 @@
+package com.wordonline.matching.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.ReactivePageableHandlerMethodArgumentResolver;
+import org.springframework.data.web.ReactiveSortHandlerMethodArgumentResolver;
+import org.springframework.web.reactive.config.WebFluxConfigurer;
+import org.springframework.web.reactive.result.method.annotation.ArgumentResolverConfigurer;
+
+@Configuration
+public class PageableWebFluxConfig implements WebFluxConfigurer {
+
+    @Override
+    public void configureArgumentResolvers(ArgumentResolverConfigurer configurer) {
+        ReactiveSortHandlerMethodArgumentResolver sortResolver =
+                new ReactiveSortHandlerMethodArgumentResolver();
+        configurer.addCustomResolver(sortResolver);
+        configurer.addCustomResolver(new ReactivePageableHandlerMethodArgumentResolver(sortResolver));
+    }
+}

--- a/src/test/java/com/wordonline/matching/auth/controller/UserControllerTest.java
+++ b/src/test/java/com/wordonline/matching/auth/controller/UserControllerTest.java
@@ -1,0 +1,78 @@
+package com.wordonline.matching.auth.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import com.wordonline.matching.auth.dto.UserGameRecordResponseDto;
+import com.wordonline.matching.auth.dto.UserStatisticsGamesResponseDto;
+import com.wordonline.matching.auth.service.UserIdResolver;
+import com.wordonline.matching.auth.service.UserService;
+import com.wordonline.matching.auth.service.UserStatisticsService;
+import com.wordonline.matching.global.config.PageableWebFluxConfig;
+import com.wordonline.matching.quest.service.QuestService;
+import com.wordonline.matching.session.service.LegacyGameMatchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WebFluxTest(UserController.class)
+@Import({PageableWebFluxConfig.class, UserIdResolver.class})
+class UserControllerTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private UserStatisticsService userStatisticsService;
+
+    @MockitoBean
+    private LegacyGameMatchService gameMatchService;
+
+    @MockitoBean
+    private QuestService questService;
+
+    @Test
+    @DisplayName("전적_게임_목록_조회시_Pageable_쿼리_파라미터를_해석한다")
+    void getMyStatisticsGames_ResolvesPageable() {
+        long userId = 1L;
+        UserStatisticsGamesResponseDto response = new UserStatisticsGamesResponseDto(List.of(
+                new UserGameRecordResponseDto(2L, "win")
+        ));
+
+        when(userStatisticsService.getGames(eq(userId), any(Pageable.class))).thenReturn(Mono.just(response));
+
+        webTestClient
+                .mutateWith(SecurityMockServerConfigurers.mockJwt().jwt(jwt -> jwt.claim("memberId", userId)))
+                .get()
+                .uri("/api/users/mine/statistics/games?page=2&size=15")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.games[0].opponentId").isEqualTo(2)
+                .jsonPath("$.games[0].result").isEqualTo("win");
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(userStatisticsService).getGames(eq(userId), pageableCaptor.capture());
+
+        Pageable pageable = pageableCaptor.getValue();
+        assertThat(pageable.getPageNumber()).isEqualTo(2);
+        assertThat(pageable.getPageSize()).isEqualTo(15);
+    }
+}


### PR DESCRIPTION
## 변경 사항
- `GET /api/users/mine` 응답에 `mmr` 필드를 추가했습니다.
- `GET /api/users/mine/statistics/overview` API를 추가해 전체 플레이 수와 승리 수를 조회합니다.
- `GET /api/users/mine/statistics/games` API를 추가해 전적 목록을 조회합니다.
- 전적 목록 조회에 `page`, `size` 기반 페이지네이션을 적용했습니다.
- 전적 데이터는 lobby-server의 `schema.sql`이 아니라 database repo 기준 기존 테이블인 `statistic_games`를 사용합니다.
- contributor guide인 `AGENTS.md`를 추가했습니다.

## 확인 사항
- `./gradlew compileJava compileKotlin` 통과

Closes #37