### PR TITLE
fix: map random bot query result to persona entity

### DIFF
--- a/src/main/kotlin/com/wordonline/matching/matching/repository/BotPersonaRepository.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/repository/BotPersonaRepository.kt
@@ -10,12 +10,12 @@ interface BotPersonaRepository : R2dbcRepository<BotPersona, Long> {
 
     @Query(
         """
-        SELECT user_id
+        SELECT user_id, name, enabled
         FROM bot_personas
         WHERE enabled = TRUE
         ORDER BY RANDOM()
         LIMIT 1
         """
     )
-    fun findRandomEnabledUserId(): Mono<Long>
+    fun findRandomEnabled(): Mono<BotPersona>
 }

--- a/src/main/kotlin/com/wordonline/matching/matching/service/BotMemberMaker.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/service/BotMemberMaker.kt
@@ -1,6 +1,7 @@
 package com.wordonline.matching.matching.service
 
 import com.wordonline.matching.matching.dto.AccountMemberResponseDto
+import com.wordonline.matching.matching.domain.BotPersona
 import com.wordonline.matching.matching.repository.BotPersonaRepository
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Mono
@@ -10,7 +11,8 @@ class BotMemberMaker(
     private val botPersonaRepository: BotPersonaRepository,
 ) {
 
-    fun getRandomEnabledBotId(): Mono<Long> = botPersonaRepository.findRandomEnabledUserId()
+    fun getRandomEnabledBotId(): Mono<Long> = botPersonaRepository.findRandomEnabled()
+        .map(BotPersona::userId)
         .switchIfEmpty(Mono.error(IllegalStateException("No enabled bot persona is available.")))
 
     fun getBot(botId: Long): Mono<AccountMemberResponseDto> {

--- a/src/test/java/com/wordonline/matching/matching/service/BotMemberMakerTest.java
+++ b/src/test/java/com/wordonline/matching/matching/service/BotMemberMakerTest.java
@@ -58,7 +58,8 @@ class BotMemberMakerTest {
 
     @Test
     void selectsBotFromEnabledPersonaCatalog() {
-        when(botPersonaRepository.findRandomEnabledUserId()).thenReturn(Mono.just(-12L));
+        when(botPersonaRepository.findRandomEnabled())
+                .thenReturn(Mono.just(new BotPersona(-12L, "random bot", true)));
 
         StepVerifier.create(botMemberMaker.getRandomEnabledBotId())
                 .expectNext(-12L)
@@ -67,7 +68,7 @@ class BotMemberMakerTest {
 
     @Test
     void rejectsSelectionWhenNoPersonaIsEnabled() {
-        when(botPersonaRepository.findRandomEnabledUserId()).thenReturn(Mono.empty());
+        when(botPersonaRepository.findRandomEnabled()).thenReturn(Mono.empty());
 
         StepVerifier.create(botMemberMaker.getRandomEnabledBotId())
                 .expectErrorMatches(error -> error instanceof IllegalStateException


### PR DESCRIPTION
## Summary

- map the random enabled bot query to `BotPersona` instead of directly to `Long`
- extract `userId` in `BotMemberMaker`
- update bot selection unit tests for the entity-returning repository method

## Why

Spring Data R2DBC attempted to map `RowDocument{user_id=...}` to a `Long` persistent entity for the string-based repository query, causing practice matching to fail.

## Test

```text
JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./gradlew test --tests com.wordonline.matching.matching.service.BotMemberMakerTest
BUILD SUCCESSFUL
```

Closes #50