### PR TITLE
fix(matching): 봇 페르소나 조회 R2DBC 매핑 오류 수정

### DIFF
--- a/src/main/kotlin/com/wordonline/matching/matching/repository/BotPersonaRepository.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/repository/BotPersonaRepository.kt
@@ -10,12 +10,12 @@ interface BotPersonaRepository : R2dbcRepository<BotPersona, Long> {
 
     @Query(
         """
-        SELECT user_id
+        SELECT user_id, name, enabled
         FROM bot_personas
         WHERE enabled = TRUE
         ORDER BY RANDOM()
         LIMIT 1
         """
     )
-    fun findRandomEnabledUserId(): Mono<Long>
+    fun findRandomEnabled(): Mono<BotPersona>
 }

--- a/src/main/kotlin/com/wordonline/matching/matching/service/BotMemberMaker.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/service/BotMemberMaker.kt
@@ -1,6 +1,7 @@
 package com.wordonline.matching.matching.service
 
 import com.wordonline.matching.matching.dto.AccountMemberResponseDto
+import com.wordonline.matching.matching.domain.BotPersona
 import com.wordonline.matching.matching.repository.BotPersonaRepository
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Mono
@@ -10,7 +11,8 @@ class BotMemberMaker(
     private val botPersonaRepository: BotPersonaRepository,
 ) {
 
-    fun getRandomEnabledBotId(): Mono<Long> = botPersonaRepository.findRandomEnabledUserId()
+    fun getRandomEnabledBotId(): Mono<Long> = botPersonaRepository.findRandomEnabled()
+        .map(BotPersona::userId)
         .switchIfEmpty(Mono.error(IllegalStateException("No enabled bot persona is available.")))
 
     fun getBot(botId: Long): Mono<AccountMemberResponseDto> {

--- a/src/test/java/com/wordonline/matching/matching/service/BotMemberMakerTest.java
+++ b/src/test/java/com/wordonline/matching/matching/service/BotMemberMakerTest.java
@@ -58,7 +58,8 @@ class BotMemberMakerTest {
 
     @Test
     void selectsBotFromEnabledPersonaCatalog() {
-        when(botPersonaRepository.findRandomEnabledUserId()).thenReturn(Mono.just(-12L));
+        when(botPersonaRepository.findRandomEnabled())
+                .thenReturn(Mono.just(new BotPersona(-12L, "random bot", true)));
 
         StepVerifier.create(botMemberMaker.getRandomEnabledBotId())
                 .expectNext(-12L)
@@ -67,7 +68,7 @@ class BotMemberMakerTest {
 
     @Test
     void rejectsSelectionWhenNoPersonaIsEnabled() {
-        when(botPersonaRepository.findRandomEnabledUserId()).thenReturn(Mono.empty());
+        when(botPersonaRepository.findRandomEnabled()).thenReturn(Mono.empty());
 
         StepVerifier.create(botMemberMaker.getRandomEnabledBotId())
                 .expectErrorMatches(error -> error instanceof IllegalStateException


### PR DESCRIPTION
## 문제

로비 진입(로그인 직후) `/api/match/practice/me` 호출이 500으로 실패했다.

```
MappingException: Expected to read Document RowDocument{user_id=-21}
into type class java.lang.Long but didn't find a PersistentEntity for the latter
  *__checkpoint ⇢ MatchingController#matchPractice
```

## 원인

`findRandomEnabledUserId()`가 단일 컬럼(`SELECT user_id`)을 `Mono<Long>`으로 반환했다.
`R2dbcRepository<BotPersona, Long>`의 엔티티 컨버터가 row `{user_id=-21}`를 엔티티로
매핑하려 하는데 `Long`은 PersistentEntity가 아니라 예외가 났다. 인증/로그인 문제가 아니라
봇 페르소나 조회의 반환 타입 문제.

## 변경

- `findRandomEnabled(): Mono<BotPersona>` — 전체 컬럼 조회 후 실제 엔티티로 매핑
- `BotMemberMaker`에서 `.map(BotPersona::userId)`로 id 추출
- 테스트 갱신

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)