### PR TITLE
fix: restore deploy Docker CI compilation

### DIFF
--- a/src/main/kotlin/com/wordonline/matching/matching/service/GameMatchService.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/service/GameMatchService.kt
@@ -45,12 +45,6 @@ class GameMatchService(
         return legacyGameMatchService.createSession(sessionDto).awaitSingle()
     }
 
-    suspend fun matchBots(leftBotId: Long, rightBotId: Long): MatchedInfoDto {
-        val sessionId = "admin-bot-${matchingQueueRepository.nextSessionId().awaitSingle()}"
-        val sessionDto = SessionDto.Practice(sessionId, leftBotId, rightBotId)
-        return legacyGameMatchService.createSession(sessionDto).awaitSingle()
-    }
-
     suspend fun matchPVE(userId: Long, scenarioId: Long): MatchedInfoDto {
         val sessionId = "pve-${matchingQueueRepository.nextSessionId().awaitSingle()}"
         val sessionDto = SessionDto.PVE(sessionId, userId, scenarioId)


### PR DESCRIPTION
## Summary

- remove duplicate `GameMatchService.matchBots` declaration from `deploy`
- restore Kotlin compilation in Docker image build

## Validation

- `./gradlew clean build -x test --no-daemon`
- `compileKotlin` passed
- full test compilation remains blocked by pre-existing stale `UserControllerTest` references on `deploy`

Closes #55