### PR TITLE
fix: swap userId/magicId in giveMagic insert

### DIFF
--- a/src/main/java/com/wordonline/matching/magic/domain/UserMagic.java
+++ b/src/main/java/com/wordonline/matching/magic/domain/UserMagic.java
@@ -17,8 +17,4 @@ public class UserMagic {
     private Long id;
     private Long magicId;
     private Long userId;
-
-    public UserMagic(Long magicId, Long userId) {
-        this(null, magicId, userId);
-    }
 }

--- a/src/main/java/com/wordonline/matching/magic/service/MagicService.java
+++ b/src/main/java/com/wordonline/matching/magic/service/MagicService.java
@@ -26,7 +26,7 @@ public class MagicService {
     }
 
     public Mono<Void> giveMagic(long userId, long magicId) {
-        return userMagicRepository.save(new UserMagic(userId, magicId))
+        return userMagicRepository.save(new UserMagic(null, magicId, userId))
                 .then();
     }
 }

--- a/src/test/java/com/wordonline/matching/magic/service/MagicServiceTest.java
+++ b/src/test/java/com/wordonline/matching/magic/service/MagicServiceTest.java
@@ -1,0 +1,43 @@
+package com.wordonline.matching.magic.service;
+
+import com.wordonline.matching.magic.domain.UserMagic;
+import com.wordonline.matching.magic.repository.UserMagicRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MagicServiceTest {
+
+    @Mock
+    private UserMagicRepository userMagicRepository;
+
+    @InjectMocks
+    private MagicService magicService;
+
+    @Test
+    @DisplayName("마법_지급시_유저와_마법_식별자가_뒤바뀌지_않고_저장됨")
+    void giveMagic_SavesUserIdAndMagicIdInCorrectFields() {
+        when(userMagicRepository.save(any(UserMagic.class)))
+                .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(magicService.giveMagic(7L, 3L))
+                .verifyComplete();
+
+        ArgumentCaptor<UserMagic> captor = ArgumentCaptor.forClass(UserMagic.class);
+        verify(userMagicRepository).save(captor.capture());
+        UserMagic saved = captor.getValue();
+        assert saved.getUserId().equals(7L);
+        assert saved.getMagicId().equals(3L);
+    }
+}


### PR DESCRIPTION
## 요약

`UserMagic`의 2-인자 생성자는 `(magicId, userId)` 순서였는데 `MagicService.giveMagic`이 `new UserMagic(userId, magicId)`로 호출해 user_id와 magic_id가 뒤바뀐 채 저장되고 있었습니다. 모호한 동일 타입 2-인자 편의 생성자를 제거하고 호출부를 `new UserMagic(null, magicId, userId)`로 바꿔 필드 순서가 호출 지점에서 드러나게 했습니다. 저장되는 `UserMagic`의 userId/magicId를 검증하는 단위 테스트를 추가했습니다.

## 대상 이슈

Closes #57

## 검증

Ran `./gradlew build` in the worktree root. Result: BUILD FAILED, "26 tests completed, 3 failed". All 3 failures are Spring context-load failures in DataControllerTest (2) and CardControllerTest (1), caused by `Failed to bind properties under 'server.port' to java.lang.Integer` / `For input string: "${PORT}"` — the PORT env var is unset in this sandbox (AGENTS.md documents PORT/DATABASE_URL/etc. as required env). Those tests are @SpringBootTest and touch neither MagicService nor UserMagic; my diff cannot affect them. Compilation succeeded (compileJava, compileKotlin, compileTestJava all built). Then ran `./gradlew test --tests 'com.wordonline.matching.magic.service.MagicServiceTest'` → BUILD SUCCESSFUL, and the JUnit XML reports tests="1" skipped="0" failures="0" errors="0". I did not observe a fully green `./gradlew build`.

## 테스트

<worktree root> — Mockito ArgumentCaptor on UserMagicRepository.save, asserts giveMagic(7L, 3L) persists getUserId()==7 and getMagicId()==3. Matches the existing convention in this test source set (MockitoExtension + StepVerifier + Korean @DisplayName + bare `assert`, same as MagicDataServiceTest).

## 리뷰어 참고

Defect confirmed before editing: UserMagic declared fields in order (id, magicId, userId) with a hand-written convenience constructor `UserMagic(Long magicId, Long userId)`, while MagicService called `new UserMagic(userId, magicId)` — arguments swapped exactly as the issue described. Grepped `new UserMagic` across src/: MagicService was the only caller, so deleting the ambiguous constructor is safe and there are no sibling callers left broken. The signup path via UserRepository.initUserMagic uses named-column raw SQL and was never affected, as the issue noted; left untouched. Commit c034a7f, pushed to origin/fix/57, working tree clean. No PR created. Residual risk: any rows already written by the buggy path are still wrong in the DB — this patch does not include a data backfill, and one would need to come from WordOnlineDatabase per the module's AGENTS.md (no production SQL in this repo).

---
멀티 에이전트 코드 리뷰에서 검증된 결함을 수정한 것. 격리된 워크트리에서 작업하고 모듈 빌드로 확인함.
