### PR TITLE
fix: absorb healthcheck timeout into false

### DIFF
--- a/src/main/java/com/wordonline/matching/server/client/GameServerClient.java
+++ b/src/main/java/com/wordonline/matching/server/client/GameServerClient.java
@@ -40,8 +40,8 @@ public class GameServerClient {
                 .uri("/healthcheck")
                 .retrieve()
                 .toBodilessEntity()
+                .timeout(Duration.ofSeconds(2))
                 .map(responseEntity -> responseEntity.getStatusCode().is2xxSuccessful())
-                .onErrorReturn(false)
-                .timeout(Duration.ofSeconds(2));
+                .onErrorReturn(false);
     }
 }

--- a/src/main/java/com/wordonline/matching/server/service/GameServerManagementService.java
+++ b/src/main/java/com/wordonline/matching/server/service/GameServerManagementService.java
@@ -62,7 +62,11 @@ public class GameServerManagementService {
     private Mono<Void> healthCheck() {
         return Flux.fromIterable(gameServers)
                 .flatMap(server ->
-                    gameServerClient.healthcheck(server.getUrl())
+                    Mono.defer(() -> gameServerClient.healthcheck(server.getUrl()))
+                            .onErrorResume(error -> {
+                                log.error("[Error] while healthcheck game server {}", server.getId(), error);
+                                return Mono.just(false);
+                            })
                             .map(server::updateState)
                 )
                 .then();

--- a/src/test/java/com/wordonline/matching/server/client/GameServerClientTest.java
+++ b/src/test/java/com/wordonline/matching/server/client/GameServerClientTest.java
@@ -1,0 +1,52 @@
+package com.wordonline.matching.server.client;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GameServerClientTest {
+
+    @Mock
+    private WebClient.Builder builder;
+    @Mock
+    private WebClient webClient;
+    @Mock
+    private WebClient.RequestHeadersUriSpec<?> request;
+    @Mock
+    private WebClient.ResponseSpec response;
+
+    private GameServerClient gameServerClient;
+
+    @BeforeEach
+    void setUp() {
+        when(builder.baseUrl("http://game")).thenReturn(builder);
+        when(builder.build()).thenReturn(webClient);
+        gameServerClient = new GameServerClient(builder);
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void 응답이_없는_서버는_타임아웃되면_false를_반환한다() {
+        WebClient.RequestHeadersUriSpec rawRequest = request;
+        when(webClient.get()).thenReturn(rawRequest);
+        when(rawRequest.uri("/healthcheck")).thenReturn(rawRequest);
+        when(rawRequest.retrieve()).thenReturn(response);
+        when(response.toBodilessEntity()).thenReturn(Mono.never());
+
+        StepVerifier.withVirtualTime(() -> gameServerClient.healthcheck("http://game"))
+                .thenAwait(Duration.ofSeconds(3))
+                .expectNext(false)
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
## 요약

GameServerClient.healthcheck()에서 2초 timeout이 onErrorReturn(false) 뒤에 있어 TimeoutException이 Mono 밖으로 새어나가던 것을 toBodilessEntity() 직후로 옮겨 다른 에러와 동일하게 false로 흡수되도록 했습니다. 또한 GameServerManagementService.healthCheck()의 flatMap 내부에 Mono.defer + onErrorResume을 추가해, 서버 하나의 실패가 전체 헬스체크 패스를 취소시키지 않고 해당 서버만 INACTIVE로 표시되도록 격리했습니다.

## 대상 이슈

Closes #58

## 검증

Ran `./gradlew build` in the worktree root. Result: BUILD FAILED — "26 tests completed, 3 failed". The 3 failures are DataControllerTest (2) and CardControllerTest (1), all Spring context load failures: ConfigurationPropertiesBindException -> ConversionFailedException -> NumberFormatException (missing env config). I verified these are pre-existing and unrelated by running `git stash -u` and re-running `./gradlew test --tests DataControllerTest --tests CardControllerTest` on the clean tree: same "3 tests completed, 3 failed" with the identical NumberFormatException cause. Restored with `git stash pop`. Compilation succeeded in both runs (compileJava, compileKotlin, compileTestJava all ran clean). My new test: `./gradlew test --tests 'com.wordonline.matching.server.client.GameServerClientTest'` -> BUILD SUCCESSFUL. I also confirmed the test actually catches the defect: temporarily reverting the operator order in GameServerClient made that test FAIL, and restoring the fix made it pass again. Committed and pushed to origin/fix/58 (new branch created remotely).

## 테스트

<worktree root> — mocks WebClient the same way the existing AccountClientTest does, stubs toBodilessEntity() as Mono.never(), and uses StepVerifier.withVirtualTime to assert healthcheck() emits false and completes instead of erroring. Verified it fails against the pre-fix operator order. No test was added for the GameServerManagementService isolation change: gameServers is a private field populated from a reactive repository, healthCheck() is private, and the Server entity has no public constructor or setters, so exercising it would need reflection or a live DB — impractical for the size of the change.

## 리뷰어 참고

Both claims in the issue held up on inspection. Two notes on the service-side change. (1) I wrapped the client call in Mono.defer before attaching onErrorResume. This matters: server.getUrl() throws IllegalStateException when protocol/domain/port is null, and it is invoked synchronously inside the flatMap mapper, so without defer the exception goes to the outer sequence via onOperatorError and the inner onErrorResume never sees it — the isolation would have been dead code, since after the client reorder healthcheck() itself no longer errors. (2) The error path resolves to Mono.just(false), so an unreachable/misconfigured server gets marked INACTIVE rather than silently skipped. This is a small behavior addition beyond a pure "don't cancel the pass" fix, but it is consistent with the existing semantics (any HTTP failure already maps to false -> INACTIVE) and it is what actually closes the stated failure scenario of a bad server staying ACTIVE forever. Out of scope, not touched: update() and load() still only log errors from subscribe(), and there is no retry or backoff on the 60s pass; getAvailableServer() still returns the first ACTIVE server with no load balancing. Residual risk is low — the diff is 7 insertions across two files and the pre-existing test failures are environmental, so `./gradlew build` will keep failing in this environment until the missing config env vars are supplied.

---
멀티 에이전트 코드 리뷰에서 검증된 결함을 수정한 것. 격리된 워크트리에서 작업하고 모듈 빌드로 확인함.
