### PR TITLE
fix: probe session liveness on its own game server

### DIFF
--- a/src/main/java/com/wordonline/matching/session/service/LegacyGameMatchService.java
+++ b/src/main/java/com/wordonline/matching/session/service/LegacyGameMatchService.java
@@ -37,36 +37,34 @@ public class LegacyGameMatchService {
     public Mono<MatchedInfoDto> createSession(SessionDto sessionDto) {
         Optional<Server> optionalServer = gameServerManagementService.getAvailableServer();
         return getWebClient(optionalServer).flatMap(webClient ->
-                webClient.post().uri("/api/server/game-sessions")
-                        .body(Mono.just(sessionDto), SessionDto.class)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .retrieve()
-                        .bodyToMono(SimpleBooleanDto.class)
-                        .map(SimpleBooleanDto::value)
-                        .doOnNext(isSuccess -> log.info("Response from game server: {}", isSuccess))
-                        .flatMap(isSuccess -> {
-                            if (!isSuccess) return getException();
-                            log.info("Session Created");
-                            return getUserDetails(sessionDto.getUid1(), sessionDto.getUid2())
-                                    .flatMap(tuple -> {
-                                        MatchedInfoDto matchedInfoDto = new MatchedInfoDto(
-                                                "Successfully Matched",
-                                                optionalServer.get().getUrl(),
-                                                tuple.getT1(),
-                                                tuple.getT2(),
-                                                sessionDto.getSessionId()
-                                        );
-                                        return sessionRecoveryStore.storeMatchInfo(matchedInfoDto)
-                                                .thenReturn(matchedInfoDto);
-                                    });
-                        }));
+                getUserDetails(sessionDto.getUid1(), sessionDto.getUid2()).flatMap(tuple ->
+                        webClient.post().uri("/api/server/game-sessions")
+                                .body(Mono.just(sessionDto), SessionDto.class)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .retrieve()
+                                .bodyToMono(SimpleBooleanDto.class)
+                                .map(SimpleBooleanDto::value)
+                                .doOnNext(isSuccess -> log.info("Response from game server: {}", isSuccess))
+                                .flatMap(isSuccess -> {
+                                    if (!isSuccess) return getException();
+                                    log.info("Session Created");
+                                    MatchedInfoDto matchedInfoDto = new MatchedInfoDto(
+                                            "Successfully Matched",
+                                            optionalServer.get().getUrl(),
+                                            tuple.getT1(),
+                                            tuple.getT2(),
+                                            sessionDto.getSessionId()
+                                    );
+                                    return sessionRecoveryStore.storeMatchInfo(matchedInfoDto)
+                                            .thenReturn(matchedInfoDto);
+                                })));
     }
 
     public Mono<MatchedInfoDto> getMatchInfo(long userId) {
         return sessionRecoveryStore.getSessionInfo(userId)
                 .switchIfEmpty(Mono.error(new IllegalArgumentException("Session Not Found")))
                 .flatMap(sessionRecoveryInfo ->
-                        checkSessionActive(sessionRecoveryInfo.sessionId())
+                        checkSessionActive(sessionRecoveryInfo.serverUrl(), sessionRecoveryInfo.sessionId())
                                 .flatMap(isActive -> {
                                     if (isActive) return mapToMatchedInfo(sessionRecoveryInfo);
                                     return Mono.error(new IllegalArgumentException("Session Already Deactivated"));
@@ -86,12 +84,12 @@ public class LegacyGameMatchService {
         );
     }
 
-    private Mono<Boolean> checkSessionActive(String sessionId) {
-        return getWebClient().flatMap(webClient ->
-                webClient.get().uri("/api/server/game-sessions/" + sessionId + "/active")
-                        .retrieve()
-                        .bodyToMono(SimpleBooleanDto.class)
-                        .map(SimpleBooleanDto::value));
+    private Mono<Boolean> checkSessionActive(String serverUrl, String sessionId) {
+        return webClientBuilder.baseUrl(serverUrl).build()
+                .get().uri("/api/server/game-sessions/" + sessionId + "/active")
+                .retrieve()
+                .bodyToMono(SimpleBooleanDto.class)
+                .map(SimpleBooleanDto::value);
     }
 
     private <T> Mono<T> getException() {
@@ -100,10 +98,6 @@ public class LegacyGameMatchService {
             return Mono.error(
                     new IllegalArgumentException(localizationService.getMessage(localeContext, "error.member.not.found")));
         });
-    }
-
-    private Mono<WebClient> getWebClient() {
-        return getWebClient(gameServerManagementService.getAvailableServer());
     }
 
     private Mono<WebClient> getWebClient(Optional<Server> server) {

--- a/src/test/java/com/wordonline/matching/session/service/LegacyGameMatchServiceTest.java
+++ b/src/test/java/com/wordonline/matching/session/service/LegacyGameMatchServiceTest.java
@@ -1,0 +1,90 @@
+package com.wordonline.matching.session.service;
+
+import com.wordonline.matching.auth.dto.UserDetailResponseDto;
+import com.wordonline.matching.auth.service.UserService;
+import com.wordonline.matching.global.service.LocalizationService;
+import com.wordonline.matching.matching.dto.SessionDto;
+import com.wordonline.matching.server.entity.Server;
+import com.wordonline.matching.server.service.GameServerManagementService;
+import com.wordonline.matching.session.domain.SessionRecoveryInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LegacyGameMatchServiceTest {
+
+    @Mock
+    private SessionRecoveryStore sessionRecoveryStore;
+    @Mock
+    private LocalizationService localizationService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private GameServerManagementService gameServerManagementService;
+
+    private final List<ClientRequest> sentRequests = new ArrayList<>();
+    private LegacyGameMatchService legacyGameMatchService;
+
+    @BeforeEach
+    void setUp() {
+        WebClient.Builder webClientBuilder = WebClient.builder().exchangeFunction(request -> {
+            sentRequests.add(request);
+            return Mono.just(ClientResponse.create(HttpStatus.OK)
+                    .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                    .body("{\"value\":true}")
+                    .build());
+        });
+        legacyGameMatchService = new LegacyGameMatchService(
+                webClientBuilder, sessionRecoveryStore, localizationService, userService, gameServerManagementService);
+    }
+
+    @Test
+    void 세션이_생성된_게임_서버로_활성_여부를_조회한다() {
+        SessionRecoveryInfo recoveryInfo = new SessionRecoveryInfo(
+                1L, 2L, "session-1", "http://server-b:8080", System.currentTimeMillis() + 60_000);
+        when(sessionRecoveryStore.getSessionInfo(1L)).thenReturn(Mono.just(recoveryInfo));
+        when(userService.getUserDetail(1L)).thenReturn(Mono.just(new UserDetailResponseDto(1L, "left", "l@x.com")));
+        when(userService.getUserDetail(2L)).thenReturn(Mono.just(new UserDetailResponseDto(2L, "right", "r@x.com")));
+
+        StepVerifier.create(legacyGameMatchService.getMatchInfo(1L))
+                .expectNextCount(1)
+                .verifyComplete();
+
+        assertEquals("http://server-b:8080/api/server/game-sessions/session-1/active",
+                sentRequests.get(0).url().toString());
+    }
+
+    @Test
+    void 유저_조회에_실패하면_게임_서버에_방을_만들지_않는다() {
+        Server server = mock(Server.class);
+        when(server.getUrl()).thenReturn("http://server-a:8080");
+        when(gameServerManagementService.getAvailableServer()).thenReturn(Optional.of(server));
+        when(userService.getUserDetail(1L)).thenReturn(Mono.error(new IllegalStateException("account server down")));
+        when(userService.getUserDetail(2L)).thenReturn(Mono.just(new UserDetailResponseDto(2L, "right", "r@x.com")));
+
+        StepVerifier.create(legacyGameMatchService.createSession(SessionDto.Companion.PVP("session-1", 1L, 2L)))
+                .expectError(IllegalStateException.class)
+                .verify();
+
+        assertTrue(sentRequests.isEmpty());
+    }
+}


### PR DESCRIPTION
## 요약

#59: checkSessionActive가 임의의 가용 서버 대신 SessionRecoveryInfo.serverUrl()로 세션 활성 여부를 조회하도록 URL을 넘겨받게 고쳤고, 쓰이지 않게 된 무인자 getWebClient()를 삭제했습니다. #64: createSession에서 게임 서버 POST 이전에 유저/봇 상세 조회를 먼저 수행하도록 순서를 바꿔, 계정 서버 조회 실패 시 방이 만들어지지 않도록 했습니다.

## 대상 이슈

Closes #59
Closes #64

## 검증

Ran `./gradlew build` in the worktree: 27 tests completed, 3 failed — DataControllerTest (2) and CardControllerTest (1), all failing at Spring context load with ConfigurationPropertiesBindException -> NumberFormatException (missing PORT/DATABASE_* env). Confirmed pre-existing by `git stash -u` and re-running `./gradlew test --tests '*DataControllerTest*' --tests '*CardControllerTest*'` on the clean origin/main tree: same BUILD FAILED. My own class passes: `./gradlew test --tests '*LegacyGameMatchServiceTest*'` -> BUILD SUCCESSFUL, XML result tests="2" failures="0" errors="0". compileJava/compileKotlin/compileTestJava all succeeded as part of the build run.

## 테스트

<worktree root> — two JUnit5/Mockito/StepVerifier tests matching the module's existing style (Korean method names, @ExtendWith(MockitoExtension.class)). A real WebClient.Builder with a recording exchangeFunction captures outgoing requests: test 1 asserts the liveness probe URL is http://server-b:8080/... (the recovery info's server, not the available one — gameServerManagementService is never stubbed, so a regression would fail on strict stubs / wrong URL); test 2 asserts no request is sent at all when userService.getUserDetail errors.

## 리뷰어 참고

Both defects were confirmed in the source before editing. Scope notes: (1) Issue #59's suggested fix also asks the game server's SessionService.isSessionActive to null-check sessions.get(sessionId) and return false. That file lives in the `game` module, outside this worktree and this cluster's file, so I did not touch it — it is still worth doing as defence in depth, but the lobby-side routing fix removes the failure path described in the ticket. (2) Issue #64's suggested fix also mentions validating bot personas in AdminMatchService; I implemented only the primary reorder inside createSession, which covers every caller (matchPractice/matchBots/matchPVE/tryMatching all route through it). (3) Residual risk kept deliberately: the Redis `storeMatchInfo` write still happens after the room POST, since recovery info must not be written for a room that was never created. If that Redis write fails, tryMatching still drops both players without re-enqueueing — the ticket's fallback (re-enqueue in the catch block) was not implemented because it touches GameMatchService.kt, a different file from this cluster, and the primary fix was accepted as sufficient. (4) Pre-existing unused import `reactor.util.function.Tuples` left untouched.

---
멀티 에이전트 코드 리뷰에서 검증된 결함을 수정한 것. 격리된 워크트리에서 작업하고 모듈 빌드로 확인함.
