### PR TITLE
fix: bound game session fan-out and untangle it from tx

### DIFF
--- a/src/main/java/com/wordonline/matching/auth/service/UserService.java
+++ b/src/main/java/com/wordonline/matching/auth/service/UserService.java
@@ -3,6 +3,7 @@ package com.wordonline.matching.auth.service;
 import org.springframework.context.i18n.LocaleContext;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.wordonline.matching.auth.domain.User;
@@ -111,6 +112,7 @@ public class UserService {
                 .map(user -> user.getMmr() != null ? user.getMmr() : 0L);
     }
 
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public Mono<UserStatus> getStatus(Long userId) {
         if (userId == null || userId < 0){
             return Mono.empty();

--- a/src/main/java/com/wordonline/matching/server/client/GameServerClient.java
+++ b/src/main/java/com/wordonline/matching/server/client/GameServerClient.java
@@ -27,6 +27,7 @@ public class GameServerClient {
                 .uri("/api/server/game-sessions")
                 .retrieve()
                 .bodyToMono(RoomListDto.class)
+                .timeout(Duration.ofSeconds(3))
                 .onErrorResume(error -> {
                     log.error("Failed to fetch game sessions from server: {}", serverUrl, error);
                     return Mono.just(new RoomListDto(java.util.List.of()));

--- a/src/test/java/com/wordonline/matching/server/client/GameServerClientTest.java
+++ b/src/test/java/com/wordonline/matching/server/client/GameServerClientTest.java
@@ -1,0 +1,52 @@
+package com.wordonline.matching.server.client;
+
+import com.wordonline.matching.server.dto.RoomListDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GameServerClientTest {
+
+    @Mock
+    private WebClient.Builder builder;
+    @Mock
+    private WebClient webClient;
+    @Mock
+    private WebClient.RequestHeadersUriSpec<?> request;
+    @Mock
+    private WebClient.ResponseSpec response;
+
+    private GameServerClient gameServerClient;
+
+    @BeforeEach
+    void setUp() {
+        when(builder.baseUrl("http://game")).thenReturn(builder);
+        when(builder.build()).thenReturn(webClient);
+        gameServerClient = new GameServerClient(builder);
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void 응답하지_않는_게임_서버는_타임아웃_후_빈_방_목록을_반환한다() {
+        WebClient.RequestHeadersUriSpec rawRequest = request;
+        when(webClient.get()).thenReturn(rawRequest);
+        when(rawRequest.uri("/api/server/game-sessions")).thenReturn(rawRequest);
+        when(rawRequest.retrieve()).thenReturn(response);
+        when(response.bodyToMono(RoomListDto.class)).thenReturn(Mono.never());
+
+        StepVerifier.withVirtualTime(() -> gameServerClient.getGameSessions("http://game"))
+                .thenAwait(Duration.ofSeconds(5))
+                .expectNext(new RoomListDto(java.util.List.of()))
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
## 요약

응답 없는 게임 서버 호출을 GameServerClient.getGameSessions에 .timeout(3초)로 제한하고(TimeoutException이 기존 onErrorResume에서 빈 방 목록으로 처리됨), UserService.getStatus에 @Transactional(propagation = NOT_SUPPORTED)를 붙여 HTTP 팬아웃이 읽기-쓰기 트랜잭션 밖에서 실행되게 했습니다. 이제 폴링 요청이 R2DBC 커넥션을 무한히 점유하지 않습니다.

## 대상 이슈

Closes #60

## 검증

Ran `./gradlew build` from the worktree root. Result: BUILD FAILED at :test with 26 tests completed, 3 failed — DataControllerTest (2) and CardControllerTest (1), all failing at Spring context load with ConfigurationPropertiesBindException -> NumberFormatException (missing env vars such as PORT/DATABASE_URL). Compilation of main and test sources succeeded. I verified these 3 are pre-existing by `git stash -u` and re-running `./gradlew test --tests '*DataControllerTest*' --tests '*CardControllerTest*'` on the clean origin/main tree: same BUILD FAILED. Then `git stash pop`. My new test passes: `./gradlew test --tests '*GameServerClientTest*'` -> BUILD SUCCESSFUL. Commit pushed to origin/fix/60 (new branch); no PR created.

## 테스트

<worktree root> — mocks WebClient the same way the existing AccountClientTest does, stubs bodyToMono to Mono.never(), and uses StepVerifier.withVirtualTime to assert the call completes with an empty RoomListDto instead of hanging. Fails if the timeout is removed.

## 리뷰어 참고

Both halves of the reported defect were confirmed in the code before editing: GameServerClient.getGameSessions had no timeout (while the sibling healthcheck method already had one), and UserService carries a class-level @Transactional with getStatus calling gameSessionService.getAllGameSessions inside it.

Root-cause placement: the timeout went into GameServerClient.getGameSessions rather than into UserService, so the other caller of getAllGameSessions (GameServerController GET /api/server/game-sessions) is covered by the same one-line fix. grep confirms those are the only two callers.

I chose the narrower of the two suggested transaction fixes: @Transactional(propagation = Propagation.NOT_SUPPORTED) on getStatus only, rather than dropping the class-level @Transactional and re-annotating writers. NOT_SUPPORTED is honored by AbstractReactiveTransactionManager (Boot auto-configures R2dbcTransactionManager here; there is no explicit transaction-manager bean in the module).

Out of scope, noticed but not changed:
- GameServerClient.healthcheck places .timeout(2s) AFTER .onErrorReturn(false), so a TimeoutException there propagates instead of yielding false. That is a real ordering bug but belongs to the separate healthcheck issue referenced in the detail text, not to #60.
- getUserDetail and getMmr also run under the class-level read-write transaction unnecessarily (getUserDetail makes an account-server HTTP call). Not touched; left for the broader "annotate only writers" cleanup if someone wants it.
- The 3 pre-existing test failures are environment-driven (no DB/env vars) and were failing identically before my change.

---
멀티 에이전트 코드 리뷰에서 검증된 결함을 수정한 것. 격리된 워크트리에서 작업하고 모듈 빌드로 확인함.
