### PR TITLE
fix: enforce card ownership in deck validation

### DIFF
--- a/src/main/java/com/wordonline/matching/deck/service/DeckService.java
+++ b/src/main/java/com/wordonline/matching/deck/service/DeckService.java
@@ -58,7 +58,7 @@ public class DeckService {
                     return deckCardRepository.findAllByDeckId(user.getSelectedDeckId())
                             .flatMap(deckCard -> Flux.range(0, deckCard.getCount()).map(i -> deckCard.getCardId()))
                             .collectList()
-                            .flatMap(deckValidator::isValid);
+                            .flatMap(cardIds -> deckValidator.isValid(userId, cardIds));
                 })
                 .defaultIfEmpty(false);
     }
@@ -83,7 +83,7 @@ public class DeckService {
 
     public Mono<DeckResponseDto> saveDeck(long userId, DeckRequestDto deckRequestDto) {
         Deck deck = new Deck(userId, deckRequestDto.name());
-        return deckValidator.isValid(deckRequestDto.cardIds())
+        return deckValidator.isValid(userId, deckRequestDto.cardIds())
                 .flatMap(isValid -> {
                     if (!isValid) {
                         return Mono.error(new IllegalArgumentException("Invalid deck"));
@@ -96,7 +96,7 @@ public class DeckService {
     }
 
     public Mono<DeckResponseDto> updateDeck(long userId, long deckId, DeckRequestDto deckRequestDto) {
-        return deckValidator.isValid(deckRequestDto.cardIds())
+        return deckValidator.isValid(userId, deckRequestDto.cardIds())
                 .flatMap(isValid -> {
                     if (!isValid) {
                         return Mono.error(new IllegalArgumentException("Invalid deck"));

--- a/src/main/java/com/wordonline/matching/deck/validation/DeckValidator.java
+++ b/src/main/java/com/wordonline/matching/deck/validation/DeckValidator.java
@@ -7,8 +7,10 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
+import com.wordonline.matching.deck.domain.UserCard;
 import com.wordonline.matching.deck.dto.CardDto;
 import com.wordonline.matching.deck.dto.CardType;
+import com.wordonline.matching.deck.repository.UserCardRepository;
 import com.wordonline.matching.deck.service.DeckDataService;
 
 import lombok.RequiredArgsConstructor;
@@ -19,26 +21,39 @@ import reactor.core.publisher.Mono;
 public class DeckValidator {
 
     private final DeckDataService deckDataService;
+    private final UserCardRepository userCardRepository;
     public static final int DECK_CARD_COUNT = 15;
     public static final int LEAST_NUM_OF_MAGIC_CARD_TYPE = 3;
     public static final int LEAST_NUM_OF_TYPE_CARD_TYPE = 2;
     public static final int MAX_NUM_OF_SAME_CARD = 3;
 
-    public Mono<Boolean> isValid(List<Long> cardIds) {
+    public Mono<Boolean> isValid(long userId, List<Long> cardIds) {
         if (cardIds == null || cardIds.size() != DECK_CARD_COUNT) {
             return Mono.just(false);
         }
 
-        return deckDataService.getCardDtoMap()
-                .map(cards -> {
-                    Map<Long, Long> cardCounts = cardIds.stream()
-                            .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+        Map<Long, Long> cardCounts = cardIds.stream()
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
 
-                    if (cardCounts.values().stream().anyMatch(count -> count > MAX_NUM_OF_SAME_CARD)) {
+        if (cardCounts.values().stream().anyMatch(count -> count > MAX_NUM_OF_SAME_CARD)) {
+            return Mono.just(false);
+        }
+
+        return Mono.zip(
+                        deckDataService.getCardDtoMap(),
+                        userCardRepository.findAllByUserId(userId)
+                                .collectMap(UserCard::getCardId, UserCard::getCount))
+                .map(tuple -> {
+                    Map<Long, CardDto> cards = tuple.getT1();
+                    Map<Long, Integer> ownedCounts = tuple.getT2();
+
+                    if (!cards.keySet().containsAll(cardCounts.keySet())) {
                         return false;
                     }
 
-                    if (!cards.keySet().containsAll(cardCounts.keySet())) {
+                    boolean allOwned = cardCounts.entrySet().stream()
+                            .allMatch(entry -> entry.getValue() <= ownedCounts.getOrDefault(entry.getKey(), 0));
+                    if (!allOwned) {
                         return false;
                     }
 

--- a/src/test/java/com/wordonline/matching/deck/validation/DeckValidatorTest.java
+++ b/src/test/java/com/wordonline/matching/deck/validation/DeckValidatorTest.java
@@ -11,27 +11,36 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.wordonline.matching.deck.domain.UserCard;
 import com.wordonline.matching.deck.dto.CardDto;
 import com.wordonline.matching.deck.dto.CardType;
+import com.wordonline.matching.deck.repository.UserCardRepository;
 import com.wordonline.matching.deck.service.DeckDataService;
 
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 @ExtendWith(MockitoExtension.class)
 class DeckValidatorTest {
 
+    private static final long USER_ID = 1L;
+
     @Mock
     private DeckDataService deckDataService;
+
+    @Mock
+    private UserCardRepository userCardRepository;
 
     @InjectMocks
     private DeckValidator deckValidator;
 
     @Test
     void isValid_ReturnsTrue_WhenDeckSatisfiesStandard() {
-        when(deckDataService.getCardDtoMap()).thenReturn(Mono.just(cardMap()));
+        stubCards();
+        stubOwnedCards(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L);
 
-        StepVerifier.create(deckValidator.isValid(List.of(
+        StepVerifier.create(deckValidator.isValid(USER_ID, List.of(
                         1L, 1L, 2L, 3L, 3L, 3L, 4L, 5L, 5L,
                         6L, 7L, 8L, 9L, 10L, 11L
                 )))
@@ -41,16 +50,14 @@ class DeckValidatorTest {
 
     @Test
     void isValid_ReturnsFalse_WhenDeckSizeIsNotFifteen() {
-        StepVerifier.create(deckValidator.isValid(List.of(1L, 2L)))
+        StepVerifier.create(deckValidator.isValid(USER_ID, List.of(1L, 2L)))
                 .expectNext(false)
                 .verifyComplete();
     }
 
     @Test
     void isValid_ReturnsFalse_WhenSameCardIsMoreThanThree() {
-        when(deckDataService.getCardDtoMap()).thenReturn(Mono.just(cardMap()));
-
-        StepVerifier.create(deckValidator.isValid(List.of(
+        StepVerifier.create(deckValidator.isValid(USER_ID, List.of(
                         1L, 1L, 1L, 1L, 2L, 3L, 4L, 5L, 5L,
                         6L, 7L, 8L, 9L, 10L, 11L
                 )))
@@ -60,9 +67,10 @@ class DeckValidatorTest {
 
     @Test
     void isValid_ReturnsFalse_WhenMagicTypesAreLessThanThree() {
-        when(deckDataService.getCardDtoMap()).thenReturn(Mono.just(cardMap()));
+        stubCards();
+        stubOwnedCards(1L, 2L, 6L, 7L, 8L);
 
-        StepVerifier.create(deckValidator.isValid(List.of(
+        StepVerifier.create(deckValidator.isValid(USER_ID, List.of(
                         1L, 1L, 1L, 2L, 2L, 2L, 6L, 6L, 6L,
                         7L, 7L, 7L, 8L, 8L, 8L
                 )))
@@ -72,14 +80,62 @@ class DeckValidatorTest {
 
     @Test
     void isValid_ReturnsFalse_WhenAttributeTypesAreLessThanTwo() {
-        when(deckDataService.getCardDtoMap()).thenReturn(Mono.just(cardMap()));
+        stubCards();
+        stubOwnedCards(1L, 2L, 3L, 4L, 6L);
 
-        StepVerifier.create(deckValidator.isValid(List.of(
+        StepVerifier.create(deckValidator.isValid(USER_ID, List.of(
                         1L, 1L, 1L, 2L, 2L, 2L, 3L, 3L, 3L,
                         4L, 4L, 4L, 6L, 6L, 6L
                 )))
                 .expectNext(false)
                 .verifyComplete();
+    }
+
+    @Test
+    void isValid_ReturnsFalse_WhenCardIsNotOwned() {
+        stubCards();
+        stubOwnedCards(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L);
+
+        StepVerifier.create(deckValidator.isValid(USER_ID, List.of(
+                        1L, 1L, 2L, 3L, 3L, 3L, 4L, 5L, 5L,
+                        6L, 7L, 8L, 9L, 10L, 11L
+                )))
+                .expectNext(false)
+                .verifyComplete();
+    }
+
+    @Test
+    void isValid_ReturnsFalse_WhenOwnedCountIsLessThanRequested() {
+        stubCards();
+        when(userCardRepository.findAllByUserId(USER_ID)).thenReturn(Flux.just(
+                new UserCard(USER_ID, 1L, 3),
+                new UserCard(USER_ID, 2L, 3),
+                new UserCard(USER_ID, 3L, 1),
+                new UserCard(USER_ID, 4L, 3),
+                new UserCard(USER_ID, 5L, 3),
+                new UserCard(USER_ID, 6L, 3),
+                new UserCard(USER_ID, 7L, 3),
+                new UserCard(USER_ID, 8L, 3),
+                new UserCard(USER_ID, 9L, 3),
+                new UserCard(USER_ID, 10L, 3),
+                new UserCard(USER_ID, 11L, 3)
+        ));
+
+        StepVerifier.create(deckValidator.isValid(USER_ID, List.of(
+                        1L, 1L, 2L, 3L, 3L, 3L, 4L, 5L, 5L,
+                        6L, 7L, 8L, 9L, 10L, 11L
+                )))
+                .expectNext(false)
+                .verifyComplete();
+    }
+
+    private void stubCards() {
+        when(deckDataService.getCardDtoMap()).thenReturn(Mono.just(cardMap()));
+    }
+
+    private void stubOwnedCards(Long... cardIds) {
+        when(userCardRepository.findAllByUserId(USER_ID)).thenReturn(
+                Flux.fromArray(cardIds).map(cardId -> new UserCard(USER_ID, cardId, 3)));
     }
 
     private Map<Long, CardDto> cardMap() {


### PR DESCRIPTION
## 요약

DeckValidator.isValid에 userId를 넘기고 user_cards 소유 정보를 대조하도록 고쳤다. 요청된 카드 중 하나라도 미보유이거나 요청 장수가 보유 수량을 넘으면 덱 검증이 실패한다. 검증기 한 곳만 고쳐서 saveDeck, updateDeck, hasValidSelectedDeck 세 경로가 모두 막힌다.

## 대상 이슈

Closes #61

## 검증

Ran `./gradlew build` in the worktree: 27 tests completed, 3 failed — DataControllerTest (x2) and CardControllerTest, all failing at Spring context load with ConfigurationPropertiesBindException -> NumberFormatException (missing env vars, no DB). Confirmed pre-existing by `git stash` + `./gradlew test` on the clean origin/main tree: same task failed there too, then `git stash pop`. Fell back to `./gradlew compileJava compileKotlin compileTestJava compileTestKotlin` -> BUILD SUCCESSFUL. Then `./gradlew test --tests '*DeckValidatorTest*'` -> BUILD SUCCESSFUL (all 7 tests in that class pass, including the 2 new ownership tests).

## 테스트

<worktree root> — added isValid_ReturnsFalse_WhenCardIsNotOwned and isValid_ReturnsFalse_WhenOwnedCountIsLessThanRequested; existing 5 tests updated for the new signature and the mocked UserCardRepository.

## 리뷰어 참고

Defect confirmed as reported: isValid took only cardIds and never touched user_cards; DeckService called it from saveDeck, updateDeck and hasValidSelectedDeck, all of which already have userId in scope.

Fix: injected UserCardRepository into DeckValidator, changed the signature to isValid(long userId, List<Long> cardIds), and zipped findAllByUserId(userId) collected to a cardId->count map alongside the existing card map. Rejects unless every requested cardId is present in user_cards with count >= requested copies. Hoisted the size and MAX_NUM_OF_SAME_CARD checks above the reactive call so an obviously-bad deck short-circuits without a DB round trip (this is why the "more than three copies" test no longer stubs getCardDtoMap — Mockito strict stubs would flag it as unnecessary).

Backwards-compat checked: UserRepository.initUserCard seeds 3 copies of every card with access_type = 'DEFAULT' at user creation, so existing decks built from default cards still validate. A user whose row count for a card was later reduced below what an old deck holds would now fail hasValidSelectedDeck and be blocked from queueing — that is the intended behavior per the issue, but it is a behavior change for any such pre-existing deck.

Out of scope, still true: the game server does not re-verify ownership on its side, so the lobby remains the sole trust boundary. Not addressed here.

Build note for the reviewer: `./gradlew build` does not go green in this environment — 3 Spring context tests fail on missing env/DB both with and without my change. Verified pre-existing by stashing.

---
멀티 에이전트 코드 리뷰에서 검증된 결함을 수정한 것. 격리된 워크트리에서 작업하고 모듈 빌드로 확인함.
