### PR TITLE
fix: gate solo sessions and report cancel failure

### DIFF
--- a/src/main/java/com/wordonline/matching/adventure/repository/UserScenarioRepository.java
+++ b/src/main/java/com/wordonline/matching/adventure/repository/UserScenarioRepository.java
@@ -57,6 +57,8 @@ public interface UserScenarioRepository extends R2dbcRepository<UserScenario, Lo
     )
     Mono<Void> updateStateActiveWhenBeforeScenarioIsFinished(Long userId);
 
+    Mono<UserScenario> findByUserIdAndScenarioId(Long userId, Long scenarioId);
+
     @Query(
             """
             SELECT COUNT(*) AS count

--- a/src/main/java/com/wordonline/matching/adventure/service/AdventureService.java
+++ b/src/main/java/com/wordonline/matching/adventure/service/AdventureService.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
+import com.wordonline.matching.adventure.domain.ContentState;
 import com.wordonline.matching.adventure.dto.AdventureDto;
 import com.wordonline.matching.adventure.dto.AdventuresResponse;
 import com.wordonline.matching.adventure.dto.ScenarioDto;
@@ -24,8 +25,16 @@ import reactor.core.publisher.Mono;
 public class AdventureService {
 
     private final UserAdventureRepository userAdventureRepository;
+    private final UserScenarioRepository userScenarioRepository;
     private final AdventureInitService adventureInitService;
     private final AdventureProgressService adventureProgressService;
+
+    public Mono<Boolean> isScenarioUnlocked(long userId, long scenarioId) {
+        return updateUserAdventures(userId)
+                .then(userScenarioRepository.findByUserIdAndScenarioId(userId, scenarioId))
+                .map(userScenario -> userScenario.getState() != ContentState.INACTIVE)
+                .defaultIfEmpty(false);
+    }
 
     public Mono<AdventuresResponse> getAdventures(Long userId) {
         return userAdventureRepository.findAllAdventureProgress(userId)

--- a/src/main/kotlin/com/wordonline/matching/matching/controller/MatchingController.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/controller/MatchingController.kt
@@ -5,6 +5,7 @@ import com.wordonline.matching.matching.dto.MatchedInfoDto
 import com.wordonline.matching.matching.dto.QueueLengthResponseDto
 import com.wordonline.matching.matching.dto.SimpleMessageDto
 import com.wordonline.matching.matching.service.GameMatchService
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -35,8 +36,11 @@ class MatchingController(
 
     @DeleteMapping("/api/match/queue/me")
     suspend fun removeFromQueue(@UserId userId: Long?): ResponseEntity<Unit> {
-        gameMatchService.removeFromQueue(userId!!)
-        return ResponseEntity.ok().build()
+        return if (gameMatchService.removeFromQueue(userId!!)) {
+            ResponseEntity.ok().build()
+        } else {
+            ResponseEntity.status(HttpStatus.CONFLICT).build()
+        }
     }
 
     @GetMapping("/api/match/length")

--- a/src/main/kotlin/com/wordonline/matching/matching/repository/MatchingQueueRepository.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/repository/MatchingQueueRepository.kt
@@ -49,10 +49,13 @@ class MatchingQueueRepository(
                     }
             }
 
-    fun remove(userId: Long): Mono<Void> =
+    /** Returns how many queue entries were actually removed (0 when the user was not queued). */
+    fun remove(userId: Long): Mono<Long> =
         redisTemplate.opsForZSet().remove(QUEUE_KEY, userId.toString() as Any)
-            .then(redisTemplate.opsForHash<String, String>().remove(MMR_KEY, userId.toString() as Any))
-            .then()
+            .flatMap { removed ->
+                redisTemplate.opsForHash<String, String>().remove(MMR_KEY, userId.toString() as Any)
+                    .thenReturn(removed)
+            }
 
     fun size(): Mono<Long> =
         redisTemplate.opsForZSet().size(QUEUE_KEY)

--- a/src/main/kotlin/com/wordonline/matching/matching/service/GameMatchService.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/service/GameMatchService.kt
@@ -1,5 +1,7 @@
 package com.wordonline.matching.matching.service
 
+import com.wordonline.matching.adventure.service.AdventureService
+import com.wordonline.matching.auth.domain.UserStatus
 import com.wordonline.matching.auth.service.UserService
 import com.wordonline.matching.deck.service.DeckService
 import com.wordonline.matching.matching.dto.MatchedInfoDto
@@ -24,8 +26,15 @@ class GameMatchService(
     private val legacyGameMatchService: LegacyGameMatchService,
     private val userService: UserService,
     private val deckService: DeckService,
-    private val matchingQueueRepository: MatchingQueueRepository
+    private val matchingQueueRepository: MatchingQueueRepository,
+    private val adventureService: AdventureService
 ) {
+    companion object {
+        // ponytail: fixed per-tick cap keeps one slow tick from running forever;
+        // raise it or make matching event-driven if the queue still backs up.
+        private const val MAX_PAIRS_PER_TICK = 20
+    }
+
     private val log = LoggerFactory.getLogger(javaClass)
     private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
         log.error("Unexpected error while trying to match users", throwable)
@@ -33,6 +42,7 @@ class GameMatchService(
     private val scope = CoroutineScope(Dispatchers.Default + exceptionHandler)
 
     suspend fun matchPractice(userId: Long): MatchedInfoDto {
+        validateCanStartSoloSession(userId)
         val sessionId = "bot-${matchingQueueRepository.nextSessionId().awaitSingle()}"
         val botId = botMemberMaker.getRandomEnabledBotId().awaitSingle()
         val sessionDto = SessionDto.Practice(sessionId, userId, botId)
@@ -46,6 +56,10 @@ class GameMatchService(
     }
 
     suspend fun matchPVE(userId: Long, scenarioId: Long): MatchedInfoDto {
+        validateCanStartSoloSession(userId)
+        if (!adventureService.isScenarioUnlocked(userId, scenarioId).awaitSingle()) {
+            throw IllegalArgumentException("Scenario is not unlocked: scenarioId=$scenarioId")
+        }
         val sessionId = "pve-${matchingQueueRepository.nextSessionId().awaitSingle()}"
         val sessionDto = SessionDto.PVE(sessionId, userId, scenarioId)
         return legacyGameMatchService.createSession(sessionDto).awaitSingle()
@@ -88,9 +102,21 @@ class GameMatchService(
         if (!hasValidDeck) throw IllegalStateException("Deck is invalid or has not been selected")
     }
 
-    suspend fun removeFromQueue(userId: Long) {
-        matchingQueueRepository.remove(userId).awaitSingleOrNull()
-        userService.markOnline(userId).awaitSingleOrNull()
+    private suspend fun validateCanStartSoloSession(userId: Long) {
+        validateSelectedDeck(userId)
+        val status = userService.getStatus(userId).awaitSingleOrNull()
+        if (status == UserStatus.OnMatching || status == UserStatus.OnPlaying) {
+            throw IllegalArgumentException("User is already matching or playing: userId=$userId")
+        }
+    }
+
+    /** Returns false when the user was not queued anymore, e.g. already picked up by matching. */
+    suspend fun removeFromQueue(userId: Long): Boolean {
+        val removed = (matchingQueueRepository.remove(userId).awaitSingleOrNull() ?: 0L) > 0
+        if (removed) {
+            userService.markOnline(userId).awaitSingleOrNull()
+        }
+        return removed
     }
 
     @Scheduled(fixedRate = 5000)
@@ -103,27 +129,30 @@ class GameMatchService(
                 }
             }
 
-            val pair = matchingQueueRepository.dequeueBestPair().awaitSingle()
-            if (pair.size < 2) return@launch
-
-            val uid1 = pair[0]
-            val uid2 = pair[1]
-            val sessionId = "session-${matchingQueueRepository.nextSessionId().awaitSingle()}"
-            val sessionDto = SessionDto.from(sessionId, uid1, uid2)
-
-            try {
-                legacyGameMatchService.createSession(sessionDto).awaitSingle()
-                log.info("Users matched: uid1={}, uid2={}, sessionId={}", uid1, uid2, sessionId)
-                userService.markPlaying(uid1).awaitSingleOrNull()
-                userService.markPlaying(uid2).awaitSingleOrNull()
-            } catch (e: Exception) {
-                log.error("Failed to create matched session: uid1={}, uid2={}, sessionId={}", uid1, uid2, sessionId, e)
-                userService.markOnline(uid1).awaitSingleOrNull()
-                userService.markOnline(uid2).awaitSingleOrNull()
-            } finally {
-                matchingQueueRepository.remove(uid1).awaitSingleOrNull()
-                matchingQueueRepository.remove(uid2).awaitSingleOrNull()
+            repeat(MAX_PAIRS_PER_TICK) {
+                val pair = matchingQueueRepository.dequeueBestPair().awaitSingle()
+                if (pair.size < 2) return@launch
+                createMatchedSession(pair[0], pair[1])
             }
+        }
+    }
+
+    private suspend fun createMatchedSession(uid1: Long, uid2: Long) {
+        val sessionId = "session-${matchingQueueRepository.nextSessionId().awaitSingle()}"
+        val sessionDto = SessionDto.from(sessionId, uid1, uid2)
+
+        try {
+            legacyGameMatchService.createSession(sessionDto).awaitSingle()
+            log.info("Users matched: uid1={}, uid2={}, sessionId={}", uid1, uid2, sessionId)
+            userService.markPlaying(uid1).awaitSingleOrNull()
+            userService.markPlaying(uid2).awaitSingleOrNull()
+        } catch (e: Exception) {
+            log.error("Failed to create matched session: uid1={}, uid2={}, sessionId={}", uid1, uid2, sessionId, e)
+            userService.markOnline(uid1).awaitSingleOrNull()
+            userService.markOnline(uid2).awaitSingleOrNull()
+        } finally {
+            matchingQueueRepository.remove(uid1).awaitSingleOrNull()
+            matchingQueueRepository.remove(uid2).awaitSingleOrNull()
         }
     }
 

--- a/src/test/kotlin/com/wordonline/matching/matching/service/GameMatchServiceTest.kt
+++ b/src/test/kotlin/com/wordonline/matching/matching/service/GameMatchServiceTest.kt
@@ -1,0 +1,93 @@
+package com.wordonline.matching.matching.service
+
+import com.wordonline.matching.adventure.service.AdventureService
+import com.wordonline.matching.auth.domain.UserStatus
+import com.wordonline.matching.auth.service.UserService
+import com.wordonline.matching.deck.service.DeckService
+import com.wordonline.matching.matching.dto.SessionDto
+import com.wordonline.matching.matching.repository.MatchingQueueRepository
+import com.wordonline.matching.session.service.LegacyGameMatchService
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import reactor.core.publisher.Mono
+
+class GameMatchServiceTest {
+
+    private val botMemberMaker = mock(BotMemberMaker::class.java)
+    private val legacyGameMatchService = mock(LegacyGameMatchService::class.java)
+    private val userService = mock(UserService::class.java)
+    private val deckService = mock(DeckService::class.java)
+    private val matchingQueueRepository = mock(MatchingQueueRepository::class.java)
+    private val adventureService = mock(AdventureService::class.java)
+
+    private lateinit var gameMatchService: GameMatchService
+
+    @BeforeEach
+    fun setUp() {
+        gameMatchService = GameMatchService(
+            botMemberMaker,
+            legacyGameMatchService,
+            userService,
+            deckService,
+            matchingQueueRepository,
+            adventureService,
+        )
+    }
+
+    @Test
+    fun `rejects PVE play for a scenario that is not unlocked`() {
+        `when`(deckService.hasValidSelectedDeck(1L)).thenReturn(Mono.just(true))
+        `when`(userService.getStatus(1L)).thenReturn(Mono.just(UserStatus.Online))
+        `when`(adventureService.isScenarioUnlocked(1L, 97L)).thenReturn(Mono.just(false))
+
+        assertThrows<IllegalArgumentException> { runBlocking { gameMatchService.matchPVE(1L, 97L) } }
+        verifyNoSessionCreated()
+    }
+
+    @Test
+    fun `rejects practice session while the user is waiting in the matching queue`() {
+        `when`(deckService.hasValidSelectedDeck(1L)).thenReturn(Mono.just(true))
+        `when`(userService.getStatus(1L)).thenReturn(Mono.just(UserStatus.OnMatching))
+
+        assertThrows<IllegalArgumentException> { runBlocking { gameMatchService.matchPractice(1L) } }
+        verifyNoSessionCreated()
+    }
+
+    @Test
+    fun `rejects practice session without a valid selected deck`() {
+        `when`(deckService.hasValidSelectedDeck(1L)).thenReturn(Mono.just(false))
+
+        assertThrows<IllegalStateException> { runBlocking { gameMatchService.matchPractice(1L) } }
+        verifyNoSessionCreated()
+    }
+
+    @Test
+    fun `reports cancellation failure when the user is no longer queued`() {
+        `when`(matchingQueueRepository.remove(1L)).thenReturn(Mono.just(0L))
+
+        assertFalse(runBlocking { gameMatchService.removeFromQueue(1L) })
+        verify(userService, never()).markOnline(1L)
+    }
+
+    @Test
+    fun `marks the user online when the queue entry is actually removed`() {
+        `when`(matchingQueueRepository.remove(1L)).thenReturn(Mono.just(1L))
+        `when`(userService.markOnline(1L)).thenReturn(Mono.empty())
+
+        assertTrue(runBlocking { gameMatchService.removeFromQueue(1L) })
+        verify(userService).markOnline(1L)
+    }
+
+    private fun verifyNoSessionCreated() {
+        verify(legacyGameMatchService, never()).createSession(any(SessionDto::class.java))
+    }
+}


### PR DESCRIPTION
## 요약

PVE/연습 세션 진입에 덱 검증과 대기중/플레이중 상태 검사를 추가하고, PVE는 해당 시나리오가 해금(ACTIVE/FINISHED)되어 있는지 서버에서 검증한 뒤에만 세션을 만든다. 대기열 취소는 실제 ZREM 개수를 확인해 이미 매칭된 경우 409를 반환하며 markOnline을 건너뛴다. 스케줄러 틱마다 최대 20쌍까지 반복 매칭한다.

## 대상 이슈

Closes #62
Closes #63
Closes #65
Closes #66

## 검증

Ran `./gradlew build` in the worktree: compileJava/compileKotlin/compileTestJava/compileTestKotlin/bootJar all succeeded; `:test` reported "30 tests completed, 3 failed". The 3 failures are DataControllerTest (x2) and CardControllerTest — @SpringBootTest context load failures (ConfigurationPropertiesBindException -> NumberFormatException, missing env like PORT/DB). Confirmed pre-existing by `git stash -u` and re-running `./gradlew test` on clean origin/main state: same 3 failures, BUILD FAILED; then `git stash pop`. My new tests: `./gradlew test --tests com.wordonline.matching.matching.service.GameMatchServiceTest` -> BUILD SUCCESSFUL, XML result tests="5" failures="0" errors="0". Committed 58958bc and pushed `fix/62` to origin (new branch, push output confirmed).

## 테스트

<worktree root> — 5 plain Mockito/JUnit5 tests (new src/test/kotlin source dir, compiled by the existing kotlin-jvm plugin; no new dependencies): PVE rejected when scenario locked, practice rejected when OnMatching, practice rejected without valid deck, removeFromQueue false + no markOnline when ZREM count 0, true + markOnline when count 1. The tryMatching loop is not unit-tested (needs live Redis + game server).

## 리뷰어 참고

Root-cause placement: the unlock check lives in AdventureService.isScenarioUnlocked (runs the same idempotent activation the GET /api/adventures read path runs, then reads the user_scenarios row), so a brand-new user who never fetched /api/adventures is not falsely blocked on scenario 1, and any future PVE caller routes through the same gate. New derived query UserScenarioRepository.findByUserIdAndScenarioId.

#65 busy check reuses the existing UserService.getStatus, which already folds isInQueue + sessionRecoveryStore + live-room lookup into OnMatching/OnPlaying — no new duplicate logic. Side effect worth reviewing: practice/PVE start now depends on the game-server room-list call inside getStatus succeeding; if the game server is unreachable the request fails, but createSession would fail anyway. Deck validation reuses the existing validateSelectedDeck (still IllegalStateException -> 500 via GlobalExceptionHandler, same as the PVP path today; I did not change that mapping). New rejections use IllegalArgumentException -> 400.

#63: MatchingQueueRepository.remove now returns the ZREM count (Mono<Long> instead of Mono<Void>); the two other call sites (enqueue failure path, tryMatching finally block) use awaitSingleOrNull and are unaffected. DELETE /api/match/queue/me now returns 409 when nothing was removed — client-visible API change, Unity client needs to handle 409. markOnline is skipped in that case so a user already marked OnPlaying is not clobbered.

#66: implemented the throughput half only — up to MAX_PAIRS_PER_TICK = 20 pairs per 5s tick (marked with a `ponytail:` comment). The "notify the user on queue expiry" half is not implemented: there is no push channel in this module, and the existing GET /api/match/queue/me/exist polling endpoint already returns 404 for an expired entry. A real push notification would be a new mechanism, not a mechanical patch. Pairs are still created sequentially inside one coroutine, so 20 pairs can outlast a 5s tick and overlap the next tick; that overlap was already possible before this change and is safe because dequeueBestPair removes both users from Redis atomically-per-pair before session creation.

---
멀티 에이전트 코드 리뷰에서 검증된 결함을 수정한 것. 격리된 워크트리에서 작업하고 모듈 빌드로 확인함.
