### PR TITLE
fix: claim matching pair atomically via Lua

### DIFF
--- a/src/main/kotlin/com/wordonline/matching/matching/repository/MatchingQueueRepository.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/repository/MatchingQueueRepository.kt
@@ -2,6 +2,7 @@ package com.wordonline.matching.matching.repository
 
 import org.springframework.data.domain.Range
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+import org.springframework.data.redis.core.script.RedisScript
 import org.springframework.stereotype.Repository
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -15,6 +16,20 @@ class MatchingQueueRepository(
         private const val MMR_KEY = "matching:mmr"
         private const val COUNTER_KEY = "matching:session-counter"
           private const val TIMEOUT_MS = 5 * 60 * 1000L
+
+        // Claims both queue slots atomically: only removes them when both are still queued,
+        // so two overlapping matching ticks can never hand out the same pair.
+        private val CLAIM_PAIR_SCRIPT: RedisScript<Long> = RedisScript.of(
+            """
+            if redis.call('ZSCORE', KEYS[1], ARGV[1]) and redis.call('ZSCORE', KEYS[1], ARGV[2]) then
+                redis.call('ZREM', KEYS[1], ARGV[1], ARGV[2])
+                redis.call('HDEL', KEYS[2], ARGV[1], ARGV[2])
+                return 1
+            end
+            return 0
+            """.trimIndent(),
+            Long::class.javaObjectType,
+        )
     }
 
     fun enqueue(userId: Long, mmr: Long): Mono<Void> =
@@ -42,10 +57,13 @@ class MatchingQueueRepository(
 
                         val (uid1, uid2) = findClosestPair(candidates)
 
-                        Mono.`when`(
-                            redisTemplate.opsForZSet().remove(QUEUE_KEY, uid1.toString(), uid2.toString()),
-                            redisTemplate.opsForHash<String, String>().remove(MMR_KEY, uid1.toString(), uid2.toString()),
-                        ).thenReturn(listOf(uid1, uid2))
+                        redisTemplate.execute(
+                            CLAIM_PAIR_SCRIPT,
+                            listOf(QUEUE_KEY, MMR_KEY),
+                            listOf(uid1.toString(), uid2.toString()),
+                        ).next()
+                            .map { claimed -> if (claimed == 1L) listOf(uid1, uid2) else emptyList() }
+                            .defaultIfEmpty(emptyList())
                     }
             }
 
@@ -69,8 +87,10 @@ class MatchingQueueRepository(
             .collectList()
             .flatMapMany { expiredIds ->
                 if (expiredIds.isEmpty()) return@flatMapMany Flux.empty()
+                val mmrFields = expiredIds.map { it.toString() as Any }.toTypedArray()
                 redisTemplate.opsForZSet()
                     .removeRangeByScore(QUEUE_KEY, range)
+                    .then(redisTemplate.opsForHash<String, String>().remove(MMR_KEY, *mmrFields))
                     .thenMany(Flux.fromIterable(expiredIds))
             }
     }

--- a/src/test/java/com/wordonline/matching/matching/repository/MatchingQueueRepositoryTest.java
+++ b/src/test/java/com/wordonline/matching/matching/repository/MatchingQueueRepositoryTest.java
@@ -1,0 +1,93 @@
+package com.wordonline.matching.matching.repository;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.core.ReactiveHashOperations;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.data.redis.core.ReactiveZSetOperations;
+import org.springframework.data.redis.core.script.RedisScript;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings({"rawtypes", "unchecked"})
+class MatchingQueueRepositoryTest {
+
+    @Mock
+    private ReactiveStringRedisTemplate redisTemplate;
+    @Mock
+    private ReactiveZSetOperations<String, String> zSetOperations;
+    @Mock
+    private ReactiveHashOperations hashOperations;
+
+    private MatchingQueueRepository repository;
+
+    private void setUp() {
+        when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        repository = new MatchingQueueRepository(redisTemplate);
+    }
+
+    private void stubTwoQueuedUsers() {
+        when(zSetOperations.range(eq("matching:queue"), any(Range.class)))
+                .thenReturn(Flux.just("1", "2"));
+        when(hashOperations.multiGet(eq("matching:mmr"), anyList()))
+                .thenReturn(Mono.just(List.of("100", "110")));
+    }
+
+    @Test
+    void 쌍_점유에_성공하면_두_유저를_반환한다() {
+        setUp();
+        stubTwoQueuedUsers();
+        when(redisTemplate.execute(any(RedisScript.class), anyList(), anyList()))
+                .thenReturn(Flux.just(1L));
+
+        StepVerifier.create(repository.dequeueBestPair())
+                .expectNext(List.of(1L, 2L))
+                .verifyComplete();
+    }
+
+    @Test
+    void 쌍_점유에_실패하면_빈_리스트를_반환한다() {
+        setUp();
+        stubTwoQueuedUsers();
+        when(redisTemplate.execute(any(RedisScript.class), anyList(), anyList()))
+                .thenReturn(Flux.just(0L));
+
+        StepVerifier.create(repository.dequeueBestPair())
+                .expectNext(List.of())
+                .verifyComplete();
+    }
+
+    @Test
+    void 만료된_유저는_mmr_해시_필드도_함께_삭제된다() {
+        setUp();
+        when(zSetOperations.rangeByScore(eq("matching:queue"), any(Range.class)))
+                .thenReturn(Flux.just("7", "8"));
+        when(zSetOperations.removeRangeByScore(eq("matching:queue"), any(Range.class)))
+                .thenReturn(Mono.just(2L));
+        when(hashOperations.remove(eq("matching:mmr"), any(Object[].class)))
+                .thenReturn(Mono.just(2L));
+
+        StepVerifier.create(repository.removeExpired())
+                .expectNext(7L, 8L)
+                .verifyComplete();
+
+        verify(hashOperations).remove("matching:mmr", "7", "8");
+    }
+}


### PR DESCRIPTION
## 요약

`dequeueBestPair`의 후보 제거를 단일 Lua 스크립트(EVAL)로 옮겨, 두 멤버가 모두 아직 큐에 있을 때만 ZREM+HDEL하고 1을 반환하도록 했다. 경합에 밀리면 0을 받아 빈 리스트를 반환하므로 겹쳐 실행되는 두 매칭 틱이 같은 쌍을 중복 점유할 수 없다. 또한 `removeExpired`가 만료된 유저의 `matching:mmr` 해시 필드를 함께 삭제하도록 해 누수를 막았다.

## 대상 이슈

Closes #67
Closes #69

## 검증

1) `./gradlew test --tests 'com.wordonline.matching.matching.repository.MatchingQueueRepositoryTest'` -> BUILD SUCCESSFUL, tests=3 failures=0 errors=0 (read from build/test-results XML). 2) Negative control: stashed ONLY MatchingQueueRepository.kt and re-ran the same test task -> all 3 tests FAILED (WantedButNotInvoked on the mmr HDEL, AssertionError on both claim cases), then popped the stash. So the test genuinely exercises the fixed logic. 3) `./gradlew build` -> BUILD FAILED: 28 tests completed, 3 failed. The 3 failures are DataControllerTest and CardControllerTest Spring-context load failures (BindException -> ConversionFailedException -> NumberFormatException from unset env vars such as PORT/DATABASE_URL). Confirmed pre-existing: stashed all my changes including the untracked test, ran `./gradlew test` on clean origin/main state -> still BUILD FAILED with the same failing tests. 4) Fallback per instructions: `./gradlew compileJava compileKotlin compileTestJava compileTestKotlin` -> BUILD SUCCESSFUL.

## 테스트

<worktree root> - JUnit 5 + Mockito + StepVerifier (matches AccountClientTest style in the same test source set, Korean test method names per AGENTS.md). Three cases: script returns 1 -> pair returned; script returns 0 -> empty list; removeExpired deletes the matching:mmr fields for expired ids.

## 리뷰어 참고

Both claims verified against the real code before editing. Issue 67: the old code was ZRANGE -> HMGET -> in-app findClosestPair -> Mono.when(ZREM, HDEL).thenReturn(pair), discarding the ZREM count. Issue 69: removeExpired called only removeRangeByScore on QUEUE_KEY and never touched MMR_KEY (no TTL on that hash, no other reclaim path).

Design choice worth a reviewer's eye: I did NOT move the candidate scan itself into Lua (the issue's first suggestion). The script is a compare-and-claim only: `if ZSCORE m1 and ZSCORE m2 then ZREM+HDEL; return 1 else return 0`. Rationale: with both members still present at claim time the pair is still valid to hand out, so full atomicity of the *selection* is not needed for correctness - only exclusivity of the *claim* is. This also avoids the issue's own fallback suggestion (check ZREM count != 2), which is subtly worse: a partial ZREM would yank one user out of the queue while returning empty, leaving that user stuck in MATCHING with no reclaim path since removeExpired can no longer see them. The ZSCORE-guarded script never partially removes.

Consequence of the pair possibly being stale: it may no longer be the *closest* MMR pair if the ZSET changed between scan and claim. That is a heuristic-quality question, not correctness, and matches the pre-existing behavior.

Out of scope, left alone: `tryMatching` in GameMatchService.kt is still `@Scheduled` wrapping `scope.launch {}`, so ticks are still not serialized and can still overlap - the repository-level claim is what makes that safe now, but if you want ticks serialized that is a separate change. Also untouched: the odd extra indentation on the pre-existing `TIMEOUT_MS` line, and the redundant `remove(uid1)/remove(uid2)` in tryMatching's finally block (now always a no-op after a successful claim, harmless).

Note on the worktree: it is a checkout of the lobby submodule repo (Apptive-Game-Team/WordOnlineMatching) itself, so the file lives at src/main/kotlin/... not lobby/src/main/kotlin/... as the plan's `file` field implied. Branch fix/67 pushed to that submodule remote; no PR created.

---
멀티 에이전트 코드 리뷰에서 검증된 결함을 수정한 것. 격리된 워크트리에서 작업하고 모듈 빌드로 확인함.
