### PR TITLE
fix: claim quest before granting reward

### DIFF
--- a/src/main/java/com/wordonline/matching/deck/repository/UserCardRepository.java
+++ b/src/main/java/com/wordonline/matching/deck/repository/UserCardRepository.java
@@ -1,12 +1,24 @@
 package com.wordonline.matching.deck.repository;
 
+import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.r2dbc.repository.R2dbcRepository;
 
 import com.wordonline.matching.deck.domain.UserCard;
 
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 public interface UserCardRepository extends R2dbcRepository<UserCard, Long> {
 
     Flux<UserCard> findAllByUserId(Long userId);
+
+    @Query(
+            """
+            INSERT INTO user_cards(user_id, card_id, count)
+            VALUES (:userId, :cardId, :count)
+            ON CONFLICT (card_id, user_id)
+            DO UPDATE SET count = user_cards.count + :count
+            """
+    )
+    Mono<Void> addCount(Long userId, Long cardId, Integer count);
 }

--- a/src/main/java/com/wordonline/matching/quest/domain/reward/CardRewardGiver.java
+++ b/src/main/java/com/wordonline/matching/quest/domain/reward/CardRewardGiver.java
@@ -3,7 +3,6 @@ package com.wordonline.matching.quest.domain.reward;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
-import com.wordonline.matching.deck.domain.UserCard;
 import com.wordonline.matching.deck.repository.UserCardRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -23,9 +22,7 @@ public class CardRewardGiver implements RewardGiver {
 
     @Override
     public Mono<Void> give(long userId) {
-        var userCard = new UserCard(userId, (long) cardId, CARD_REWARD_AMOUNT);
-        return userCardRepository.save(userCard)
-                .then();
+        return userCardRepository.addCount(userId, (long) cardId, CARD_REWARD_AMOUNT);
     }
 
     @Override

--- a/src/main/java/com/wordonline/matching/quest/repository/UserQuestRepository.java
+++ b/src/main/java/com/wordonline/matching/quest/repository/UserQuestRepository.java
@@ -13,7 +13,8 @@ public interface UserQuestRepository extends R2dbcRepository<UserQuest, Long> {
 UPDATE user_quests
 SET state = 'COMPLETED'
 WHERE user_quests.user_id=:userId AND user_quests.quest_id=:questId
+  AND user_quests.state = 'IN_PROGRESS'
 """)
-    Mono<Void> setCompletedByUserIdAndQuestId(Long userId, Long questId);
+    Mono<Long> setCompletedByUserIdAndQuestId(Long userId, Long questId);
 }
 

--- a/src/main/java/com/wordonline/matching/quest/service/QuestService.java
+++ b/src/main/java/com/wordonline/matching/quest/service/QuestService.java
@@ -32,13 +32,13 @@ public class QuestService {
         return questRepository.findAllByUserIdAndState(userId, QuestState.IN_PROGRESS)
                 .filter(quest -> quest.getProgressChecker() != null)
                 .filterWhen(quest -> questChecker.check(userId, quest))
-                .flatMapSequential(quest -> rewardGiver.giveWithReward(userId, quest)
-                        .flatMap(reward -> markQuestCompleted(userId, quest.getId())
-                                .thenReturn(reward)))
+                .flatMapSequential(quest -> markQuestCompleted(userId, quest.getId())
+                        .filter(claimedRows -> claimedRows > 0)
+                        .flatMap(claimedRows -> rewardGiver.giveWithReward(userId, quest)))
                 .collectList();
     }
 
-    private Mono<Void> markQuestCompleted(long userId, long questId) {
+    private Mono<Long> markQuestCompleted(long userId, long questId) {
         return userQuestRepository.setCompletedByUserIdAndQuestId(userId, questId);
     }
 

--- a/src/test/java/com/wordonline/matching/quest/service/QuestServiceTest.java
+++ b/src/test/java/com/wordonline/matching/quest/service/QuestServiceTest.java
@@ -26,6 +26,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -144,11 +146,28 @@ class QuestServiceTest {
         when(questChecker.check(userId, secondQuest)).thenReturn(Mono.just(true));
         when(rewardGiver.giveWithReward(userId, quest)).thenReturn(Mono.just(firstReward));
         when(rewardGiver.giveWithReward(userId, secondQuest)).thenReturn(Mono.just(secondReward));
-        when(userQuestRepository.setCompletedByUserIdAndQuestId(userId, quest.getId())).thenReturn(Mono.empty());
-        when(userQuestRepository.setCompletedByUserIdAndQuestId(userId, secondQuest.getId())).thenReturn(Mono.empty());
+        when(userQuestRepository.setCompletedByUserIdAndQuestId(userId, quest.getId())).thenReturn(Mono.just(1L));
+        when(userQuestRepository.setCompletedByUserIdAndQuestId(userId, secondQuest.getId())).thenReturn(Mono.just(1L));
 
         StepVerifier.create(questService.checkQuestsWithRewards(userId))
                 .expectNext(List.of(firstReward, secondReward))
                 .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("퀘스트_선점_실패시_보상_미지급")
+    void checkQuestsWithRewards_SkipsRewardWhenAlreadyClaimed() {
+        long userId = 1L;
+
+        when(questRepository.findAllByUserIdAndState(userId, QuestState.IN_PROGRESS))
+                .thenReturn(Flux.just(quest));
+        when(questChecker.check(userId, quest)).thenReturn(Mono.just(true));
+        when(userQuestRepository.setCompletedByUserIdAndQuestId(userId, quest.getId())).thenReturn(Mono.just(0L));
+
+        StepVerifier.create(questService.checkQuestsWithRewards(userId))
+                .expectNext(List.of())
+                .verifyComplete();
+
+        verify(rewardGiver, never()).giveWithReward(anyLong(), any(Quest.class));
     }
 }


### PR DESCRIPTION
## 요약

보상 지급 전에 퀘스트를 선점하도록 순서를 뒤집었습니다. `setCompletedByUserIdAndQuestId`에 `AND state = 'IN_PROGRESS'` 조건을 추가하고 반환 타입을 `Mono<Long>`(영향 행 수)으로 바꿔, 실제로 1행 이상을 선점한 요청만 `rewardGiver.giveWithReward`를 호출합니다. 또한 `CardRewardGiver`의 INSERT를 `ON CONFLICT (card_id, user_id) DO UPDATE SET count = user_cards.count + :count` upsert로 바꿔, 이미 보유한 카드를 보상으로 줄 때 유니크 제약 위반으로 배치 전체가 롤백되지 않게 했습니다.

## 대상 이슈

Closes #68

## 검증

Ran `./gradlew build` in the worktree: compiled clean, `:test` reported "26 tests completed, 3 failed" — the 3 failures are DataControllerTest (x2) and CardControllerTest (x1), all Spring context load failures (ConfigurationPropertiesBindException -> NumberFormatException from missing env config, e.g. PORT/DATABASE_URL). Confirmed pre-existing by `git stash` + `./gradlew test` on the untouched origin/main tree: "25 tests completed, 3 failed" with exactly the same 3 test names. Then `git stash pop`. Ran `./gradlew test --tests com.wordonline.matching.quest.service.QuestServiceTest` on my change: BUILD SUCCESSFUL (all 4 quest service tests including the new one pass). The Postgres upsert SQL itself was not executed against a live DB — no DB is available in this environment.

## 테스트

<worktree root> — added `checkQuestsWithRewards_SkipsRewardWhenAlreadyClaimed` (@DisplayName "퀘스트_선점_실패시_보상_미지급"): the claim UPDATE returns 0 rows, the result list must be empty, and `verify(rewardGiver, never()).giveWithReward(...)`. Matches the existing Mockito + StepVerifier style in that file. Also updated the existing `checkQuestsWithRewards_Success` stubs from `Mono.empty()` to `Mono.just(1L)` for the new return type.

## 리뷰어 참고

Both defects in the issue were verified in code before editing. (1) `setCompletedByUserIdAndQuestId` really had no state predicate and returned `Mono<Void>`, and rewards really ran first. (2) `database/migration/V000_20260406__init_tables.sql:363` confirms `user_cards ... unique (card_id, user_id)`, and `CardRewardGiver` really saved a null-id `UserCard` (always an INSERT). The class-level `@Transactional` on QuestService is unchanged, so batch-wide rollback semantics stay as-is — the fix removes the cause of the constraint violation rather than narrowing the transaction.

Implementation notes: the new `UserCardRepository.addCount` upsert follows the existing `ON CONFLICT ... DO UPDATE` pattern already used in `UserScenarioRepository`, and the `Mono<Long>` row-count return type matches the existing `@Query` UPDATE methods in `UserRepository`. `ON CONFLICT (card_id, user_id)` is written in the constraint's declared column order. The claim-then-give ordering relies on Postgres READ COMMITTED re-evaluating the WHERE clause after a blocking row lock is released, which is what makes the second concurrent transaction see 0 affected rows.

Out of scope / not changed: `DecorationRewardGiver` and `MagicRewardGiver` still insert directly. `user_decorations` has no unique constraint in the migration so it duplicates silently rather than erroring, and `user_magics` does have `uq_user_magics_user_id_magic_id` — the claim guard now prevents the concurrent double-grant for both, but a quest whose reward is an already-owned magic would still raise a duplicate key. Issue 68 named only the card path, so I left those alone; worth a separate issue if magic rewards can overlap the `initUserMagic` DEFAULT grant.

Residual risk: the upsert SQL was never run against a real Postgres instance here, so a typo-level SQL error would only surface at runtime. No migration is required — the `unique (card_id, user_id)` index the upsert infers on already exists.

---
멀티 에이전트 코드 리뷰에서 검증된 결함을 수정한 것. 격리된 워크트리에서 작업하고 모듈 빌드로 확인함.
