### PR TITLE
feat: expose Prometheus metrics on a separate management port

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 
+    // Metrics
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
     testImplementation 'org.springframework.security:spring-security-test'
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,20 @@
 server:
   port: ${PORT}
 
+# Metrics run on their own port so the public app port never serves /actuator.
+# The app SecurityFilterChain does not guard the management context, so
+# MANAGEMENT_PORT must stay reachable only from the Prometheus host.
+management:
+  server:
+    port: ${MANAGEMENT_PORT:8081}
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus
+  metrics:
+    tags:
+      application: ${spring.application.name}
+
 spring:
   application:
     name: word-online-matching


### PR DESCRIPTION
Closes #86

## Summary

Adds Prometheus-scrapable metrics to this server. Nothing exposed metrics before this change.

- `spring-boot-starter-actuator` + `micrometer-registry-prometheus`
- actuator bound to `MANAGEMENT_PORT` (default `8081`), so the app port never serves `/actuator`
- only `health` and `prometheus` endpoints exposed
- every metric tagged `application=${spring.application.name}`

Scrape target: `http://<host>:8081/actuator/prometheus`.

## Why a separate port

The app port is public (client or web traffic), and this app's SecurityFilterChain would otherwise need per-path actuator rules. Splitting the port keeps metrics off the public surface without touching security config.

## Deployment notes

- **8081 is unauthenticated.** The management child context is not covered by this app's SecurityFilterChain, so the port must be firewalled to the Prometheus host only, and never proxied publicly.
- Two of these servers on one host collide on `8081`. Override `MANAGEMENT_PORT` for one. `remote-deploy.sh` only forwards variables it explicitly exports, so add it there if the override is needed.
- No change to the existing `/healthcheck` endpoint on the app port; the lobby to game-server probe is unaffected.

## Test notes

`./gradlew test` passes in a checkout that has a local `.env`. In a bare worktree without `.env` the `@WebFluxTest` context tests fail on `server.port: ${PORT}` — pre-existing behavior, reproduced identically on unmodified `main`, unrelated to this change.

Same change applied in parallel across AccountServer, WordOnlineAdmin, WordOnlineServer, and WordOnlineMatching.