### PR TITLE
fix: drop null-valued parameters from data response (#88)

### DIFF
--- a/src/main/java/com/wordonline/matching/data/service/DataService.java
+++ b/src/main/java/com/wordonline/matching/data/service/DataService.java
@@ -8,6 +8,7 @@ import com.wordonline.matching.data.repository.GameObjectRepository;
 import com.wordonline.matching.data.repository.ParameterRepository;
 import com.wordonline.matching.data.repository.ParameterValueRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 @Transactional
@@ -58,11 +60,24 @@ public class DataService {
                         return Mono.just(new ParametersResponse(List.of(), fallbackVersion, requiresRefresh));
                     }
 
-                    List<Long> gameObjectIds = parameterValues.stream()
+                    // parameter_values.value is nullable in the database, but clients model the
+                    // parameter value as a non-nullable number and fail to deserialize `null`.
+                    // Drop those rows instead of shipping an entry the client cannot consume.
+                    List<ParameterValue> serializableValues = parameterValues.stream()
+                            .filter(parameterValue -> parameterValue.getValue() != null)
+                            .collect(Collectors.toList());
+
+                    int droppedCount = parameterValues.size() - serializableValues.size();
+                    if (droppedCount > 0) {
+                        log.warn("Dropped {} of {} parameter values with a null value from the parameters response",
+                                droppedCount, parameterValues.size());
+                    }
+
+                    List<Long> gameObjectIds = serializableValues.stream()
                             .map(ParameterValue::getGameObjectId)
                             .distinct()
                             .collect(Collectors.toList());
-                    List<Long> parameterIds = parameterValues.stream()
+                    List<Long> parameterIds = serializableValues.stream()
                             .map(ParameterValue::getParameterId)
                             .distinct()
                             .collect(Collectors.toList());
@@ -77,13 +92,17 @@ public class DataService {
                                 Map<Long, GameObject> gameObjectMap = tuple.getT1();
                                 Map<Long, com.wordonline.matching.data.entity.Parameter> parameterMap = tuple.getT2();
 
+                                // Deliberately computed over the unfiltered rows: `findAllUpdatedSince`
+                                // also sees the dropped rows, so a version derived from the filtered
+                                // rows would stay behind a null row's `updated_at` forever and make a
+                                // version-caching client re-fetch the full snapshot on every request.
                                 LocalDateTime maxUpdatedAt = parameterValues.stream()
                                         .map(ParameterValue::getUpdatedAt)
                                         .filter(java.util.Objects::nonNull)
                                         .max(Comparator.naturalOrder())
                                         .orElse(null);
 
-                                List<Parameter> domainParameters = parameterValues.stream()
+                                List<Parameter> domainParameters = serializableValues.stream()
                                         .map(pv -> new Parameter(
                                                 gameObjectMap.getOrDefault(pv.getGameObjectId(), new GameObject()).getName(),
                                                 parameterMap.getOrDefault(pv.getParameterId(), new com.wordonline.matching.data.entity.Parameter()).getName(),

--- a/src/test/java/com/wordonline/matching/data/service/DataServiceTest.java
+++ b/src/test/java/com/wordonline/matching/data/service/DataServiceTest.java
@@ -144,6 +144,45 @@ class DataServiceTest {
                 .verifyComplete();
     }
 
+    @Test
+    @DisplayName("값이_null인_파라미터는_제외하되_버전은_전체_기준으로_계산")
+    void getParameters_ExcludesNullValuesButKeepsVersionOverAllRows() {
+        ParameterValue validValue = ParameterValue.builder()
+                .id(1L)
+                .gameObjectId(10L)
+                .parameterId(100L)
+                .value(100.0)
+                .updatedAt(LocalDateTime.parse("2024-01-01T00:00:00"))
+                .build();
+
+        ParameterValue nullValue = ParameterValue.builder()
+                .id(2L)
+                .gameObjectId(10L)
+                .parameterId(101L)
+                .value(null)
+                .updatedAt(LocalDateTime.parse("2024-01-03T09:00:00"))
+                .build();
+
+        when(parameterValueRepository.findAllParameters())
+                .thenReturn(Flux.just(validValue, nullValue));
+        when(gameObjectRepository.findAllById(List.of(10L)))
+                .thenReturn(Flux.just(new GameObject(10L, "player")));
+        when(parameterRepository.findAllById(List.of(100L)))
+                .thenReturn(Flux.just(new Parameter(100L, "max_hp")));
+
+        StepVerifier.create(dataService.getParameters(null))
+                .assertNext(response -> {
+                    assert response.getParameters().size() == 1;
+                    assert response.getParameters().stream().noneMatch(parameter -> parameter.getValue() == null);
+                    assert response.getParameters().get(0).getGameObjectName().equals("player");
+                    assert response.getParameters().get(0).getParamName().equals("max_hp");
+                    assert response.getParameters().get(0).getValue().equals(100.0);
+                    assert response.getVersion().equals("2024-01-03T09:00:00");
+                    assert response.isRequiresRefresh();
+                })
+                .verifyComplete();
+    }
+
     private void assertResponseContainsFullParameterSnapshot(ParametersResponse response) {
         assert response.getParameters().size() == 3;
         assert response.getParameters().stream().anyMatch(parameter ->


### PR DESCRIPTION
Closes #88

## Problem

The Unity client crashed at login while deserializing `GET /api/data/parameters`:

```
JsonSerializationException: Error converting value {null} to type 'System.Single'. Path 'parameters[94].value'
```

`parameter_values.value` is `double precision` with no `NOT NULL` constraint, `ParameterValue.value` and `Parameter.value` are nullable `Double`, and `DataService.buildParametersResponse` mapped every row straight through — so a NULL row shipped as `"value": null` to a client that models it as a non-nullable `float`.

## Change

Server-side hardening only, confined to `DataService`:

- `buildParametersResponse` filters out `ParameterValue` entries whose `getValue()` is null before mapping them into `domainParameters`. The `gameObjectIds` / `parameterIds` lookups are derived from the filtered list too, so no lookups are done for rows that will be dropped.
- A `log.warn` reports the dropped count against the total when any row is dropped, using the project's existing Lombok `@Slf4j` + `log.warn("... {} ...", args)` idiom.

No entity, domain record, schema, or migration changes. The database cleanup of the offending rows is handled separately in `WordOnlineDatabase`.

## On the `version` computation

`maxUpdatedAt` stays computed over the **unfiltered** row list, and that is deliberate.

`getParameters(currentVersion)` decides whether anything changed by calling `ParameterValueRepository.findAllUpdatedSince(version)`, and that query sees *all* rows — including the ones we drop from the payload. If the version were computed over the filtered list, a null-valued row carrying the newest `updated_at` would leave the returned version permanently behind that timestamp. Every subsequent request would find `findAllUpdatedSince(version)` non-empty, rebuild the full snapshot, and hand back the same stale version again — a client that caches by version would re-fetch the entire parameter set on every login, forever.

Computing the version over the unfiltered list keeps the version an honest high-water mark of the underlying table, so it advances past the bad row and the client settles into the `requiresRefresh: false` fast path. The cost is that a fix that only touches null rows still bumps the version and triggers one extra full fetch, which is the correct and cheap direction to err in.

## Tests

Added `getParameters_ExcludesNullValuesButKeepsVersionOverAllRows` to the existing `DataServiceTest`: a snapshot of one valid row (older `updated_at`) plus one null-valued row (newest `updated_at`) returns exactly one parameter, no null values, and a version equal to the null row's `updated_at`.

`./gradlew test` — `BUILD SUCCESSFUL`, all suites green, `DataServiceTest` at 4 tests / 0 failures.

## Coordination

Affects `GET /api/data/parameters` only. No client, game-server, or account-server change required; no migration required in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)