### PR TITLE
test: 게임 서버와의 JSON 계약을 공유 픽스처로 고정

### DIFF
--- a/src/test/kotlin/com/wordonline/matching/session/dto/GameServerContractTest.kt
+++ b/src/test/kotlin/com/wordonline/matching/session/dto/GameServerContractTest.kt
@@ -1,0 +1,73 @@
+package com.wordonline.matching.session.dto
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.wordonline.matching.matching.dto.SessionDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
+
+/**
+ * Pins the wire format of `POST /api/server/game-sessions` against fixtures shared with
+ * WordOnlineServer, which keeps byte-identical copies under the same paths.
+ *
+ * Both repositories previously checked this contract only against their own DTO classes,
+ * so a renamed field left both suites green. It would not have surfaced as an exception
+ * either: the lobby treats a response it cannot match to its `attemptId` as a refusal and
+ * moves to the next candidate, so a broken contract reads as "every server refused" and
+ * ends in a 503 with nothing in the logs naming the cause.
+ */
+class GameServerContractTest {
+
+    private val objectMapper: ObjectMapper = Jackson2ObjectMapperBuilder.json().build()
+
+    private fun fixture(name: String): String =
+        checkNotNull(javaClass.getResourceAsStream("/contract/$name")) { "missing fixture: $name" }
+            .bufferedReader()
+            .use { it.readText() }
+
+    @Test
+    fun `the request this server sends matches the shared fixture`() {
+        val request = CreateSessionRequest("attempt-1", SessionDto.PVP("session-1", 1L, 2L))
+
+        assertThat(objectMapper.readTree(objectMapper.writeValueAsString(request)))
+            .isEqualTo(objectMapper.readTree(fixture("create-session-request.json")))
+    }
+
+    @Test
+    fun `the response the game server sends is readable`() {
+        val response = objectMapper.readValue(
+            fixture("session-ready-response.json"),
+            SessionReadyResponse::class.java,
+        )
+
+        assertThat(response.attemptId).isEqualTo("attempt-1")
+        assertThat(response.sessionId).isEqualTo("session-1")
+        assertThat(response.ready).isTrue()
+        assertThat(response.serverUrl).isEqualTo("http://localhost:7777")
+        assertThat(response.webSocketUrl).isEqualTo("http://localhost:7777/ws")
+    }
+
+    @Test
+    fun `the request stays flat rather than nesting the session`() {
+        // The game server binds uid1/uid2/sessionType at the top level, so a wrapper object
+        // would leave every field null and every candidate refusing the session.
+        val json = objectMapper.readTree(fixture("create-session-request.json"))
+
+        assertThat(json.has("session")).isFalse()
+        assertThat(json.has("sessionDto")).isFalse()
+        assertThat(json.fieldNames().asSequence().toList())
+            .containsExactlyInAnyOrder("attemptId", "sessionId", "uid1", "uid2", "sessionType", "scenarioId")
+    }
+
+    @Test
+    fun `an unknown field from a newer game server does not break the response`() {
+        // The game server may ship a field before the lobby knows about it; rejecting the
+        // whole response there would read as a refusal and fail matching for no reason.
+        val extended = objectMapper.readTree(fixture("session-ready-response.json")) as com.fasterxml.jackson.databind.node.ObjectNode
+        extended.put("regionCode", "kr")
+
+        val response = objectMapper.readValue(extended.toString(), SessionReadyResponse::class.java)
+
+        assertThat(response.sessionId).isEqualTo("session-1")
+    }
+}

--- a/src/test/resources/contract/README.md
+++ b/src/test/resources/contract/README.md
@@ -1,0 +1,21 @@
+# Game server contract fixtures
+
+These files are the wire format of `POST /api/server/game-sessions`, shared with
+`Apptive-Game-Team/WordOnlineServer`. The same two files exist there under
+`src/test/resources/contract/` with identical content.
+
+- `create-session-request.json` - what this server sends. Verified here by serializing
+  `CreateSessionRequest`; verified there by deserializing into the game server's own
+  `CreateSessionRequest`.
+- `session-ready-response.json` - what the game server answers. Verified here by
+  deserializing into `SessionReadyResponse`; verified there by serializing the game
+  server's own `SessionReadyResponse`.
+
+Changing a field name or the nesting on one side alone makes the other side's test fail,
+which is the point: without these, both repositories' suites stay green through a broken
+contract. A mismatch does not surface as an exception at runtime either - the lobby reads
+it as a refusal and fails over, so every candidate is rejected and matching returns 503
+with nothing in the logs pointing at the cause.
+
+When the contract changes, update both copies in the same pull request pair and say so in
+each body.

--- a/src/test/resources/contract/create-session-request.json
+++ b/src/test/resources/contract/create-session-request.json
@@ -1,0 +1,8 @@
+{
+  "attemptId": "attempt-1",
+  "sessionId": "session-1",
+  "uid1": 1,
+  "uid2": 2,
+  "sessionType": "PVP",
+  "scenarioId": null
+}

--- a/src/test/resources/contract/session-ready-response.json
+++ b/src/test/resources/contract/session-ready-response.json
@@ -1,0 +1,7 @@
+{
+  "attemptId": "attempt-1",
+  "sessionId": "session-1",
+  "ready": true,
+  "serverUrl": "http://localhost:7777",
+  "webSocketUrl": "http://localhost:7777/ws"
+}


### PR DESCRIPTION
Closes #91

**base가 `main`이 아니라 `fix/82`다.** `CreateSessionRequest`/`SessionReadyResponse`가 그 브랜치에만 있다.

**대응 PR: Apptive-Game-Team/WordOnlineServer#368** — 같은 픽스처를 game 쪽에서 검증한다. 두 PR은 같이 머지되어야 의미가 있다.

## 왜

`POST /api/server/game-sessions`의 계약을 양쪽이 각자의 DTO 객체로만 검증하고 있었다.

- lobby `CreateSessionRequestTest`: lobby가 **보내는** JSON이 flat인지
- game `SessionServerControllerTest`: game이 **자기** DTO로 받는지

둘 사이에 실제 JSON이 오간 적이 없다. 필드명을 한쪽만 바꿔도 양쪽 스위트가 초록이다.

더 나쁜 건 깨졌을 때의 증상이다. PR #83이 도입한 `attemptId` 핸드셰이크는 불일치를 예외가 아니라 **거절**로 처리한다. lobby는 다음 후보로 넘어가고 후보를 다 쓰면 503을 낸다. 스택트레이스가 없어서 "게임 서버가 다 죽었나"로 보인다.

## 무엇을

`src/test/resources/contract/`에 픽스처 2개를 두고 WordOnlineServer가 같은 경로에 같은 내용을 갖는다.

- `create-session-request.json`
- `session-ready-response.json`

lobby 쪽 검증 4건:

- 직렬화한 `CreateSessionRequest`가 픽스처와 일치
- 픽스처 `session-ready-response.json`이 `SessionReadyResponse`로 역직렬화되고 5개 필드가 전부 보존
- 요청이 flat 유지 — `session`/`sessionDto` 래퍼가 없고 최상위 필드 집합이 정확히 6개. 래퍼가 생기면 게임 서버 쪽 필드가 전부 null이 되고 모든 후보가 거절한다
- 게임 서버가 모르는 필드를 추가로 보내도 응답 파싱이 깨지지 않음. 배포 순서가 어긋나 game이 먼저 나가도 매칭이 죽으면 안 된다

`src/test/resources/contract/README.md`에 두 저장소가 이 파일을 공유한다는 것과, 계약 변경 시 양쪽을 같은 PR 쌍으로 고쳐야 한다는 것을 적었다.

## 검증

`PORT=6211 MANAGEMENT_PORT=8084 ./gradlew test` -> BUILD SUCCESSFUL

**55 tests / 0 failures / 0 errors**. 이 클래스가 4건이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)