### PR TITLE
fix: 게임 서버 재시작 후 MATCHED 티켓 복구 (#96)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test'
     testImplementation 'org.mockito.kotlin:mockito-kotlin:5.4.0'
+    // Runs the repository's Lua scripts on the JVM so redis-side behaviour is testable
+    // without a redis server or Docker in the loop.
+    testImplementation 'org.luaj:luaj-jse:3.0.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/docs/api/matching-api.md
+++ b/docs/api/matching-api.md
@@ -146,3 +146,72 @@ Redis `MatchTicket`이 매칭 상태의 source of truth다. 상태는
 SSE 이벤트는 보관하거나 replay하지 않는다. 연결이 끊겼다가 복구되면 클라이언트는
 `GET /api/match/tickets/active`를 호출해 누락된 변경의 최종 snapshot을 동기화해야 한다.
 `ALLOCATING` lease가 만료되면 ticket은 원자적으로 `QUEUED`로 복구된다.
+
+`MATCHED`는 terminal 상태가 아니므로 TTL이 붙지 않는다. `terminal-ttl`은
+`CANCELED`, `EXPIRED`, `FAILED`에만 적용되며, terminal 전이 시
+`matching:active:<userId>`가 그 ticket을 가리키고 있을 때만 함께 해제된다.
+
+---
+
+## Session Lost Report
+
+### `POST /api/match/sessions/{sessionId}/report-lost`
+
+게임 서버 세션에 더 이상 접속할 수 없다고 신고한다. 게임 서버는 세션을 인메모리로만
+들고 있어서 프로세스가 재시작하면 세션이 로비에 알림 없이 사라지고, ticket이
+`MATCHED`에 고착돼 재큐가 막힌다. 이 엔드포인트가 그 고착을 푼다.
+
+경로가 ticket이 아니라 session 기준인 이유는 클라이언트가 legacy 매칭 흐름을 쓰기 때문에
+`sessionId`만 알고 `ticketId`는 모르기 때문이다. ticket은 서버가 토큰의 사용자로 찾는다.
+
+**인증:** 필요
+
+> **신고는 근거일 뿐 판정이 아니다.** 종료 여부는 로비가 직접 확인한다. 클라이언트가
+> 신고했다는 사실만으로 살아있는 세션이 끝나는 일은 없다.
+
+로비의 판정 순서:
+
+1. 활성 ticket의 `matchInfo.sessionId`가 경로의 `sessionId`와 다르면 `404`.
+2. ticket state가 `MATCHED`가 아니면 이미 자유로운 상태이므로 현재 snapshot을 그대로 `200`.
+3. ticket에 기록된 게임 서버 부팅 세대값(`instance_id`)이 `servers` 행의 현재 값과 다르면
+   호스트 프로세스가 재시작한 것이므로 세션 소실로 확정한다. 어느 한쪽이라도 값이 없으면
+   (구버전 게임 서버) 판단 근거로 쓰지 않고 다음 단계로 넘어간다.
+4. 호스트에 `GET /api/server/game-sessions/{sessionId}/active`를 조회한다.
+
+### Response
+
+| Status | 의미 | Body |
+|---|---|---|
+| `200 OK` | ticket이 `FAILED(SESSION_LOST)`로 정리됐거나, 정리할 것이 없었다 | MatchTicket |
+| `409 Conflict` | 세션이 살아있다. ticket은 그대로 둔다 | MatchTicket |
+| `404 Not Found` | 활성 ticket이 없거나 다른 세션이다 | 없음 |
+| `503 Service Unavailable` | 호스트 무응답. 종료 확정이 아니므로 ticket을 유지한다 | 메시지 |
+
+세션 소실이 확정되면 **상대방 ticket도 함께 정리한다.** 단, `matching:active:<상대userId>`가
+가리키는 ticket의 `matchInfo.sessionId`가 같은 세션일 때만이다. 상대가 이미 재큐해 새 ticket을
+들고 있으면 그 ticket은 건드리지 않는다. 정리된 사용자는 모두 `user_status`가 `Online`으로 돌아간다.
+
+`503`을 받은 클라이언트는 재시도해도 되지만, 로비가 해당 ticket을 재확인 대기열에 넣어
+`matching.ticket.pending-scan-interval` 주기로 다시 판정하므로 별도 폴링 없이도 곧 결론이 난다.
+
+## MATCHED reconciler
+
+양쪽 클라이언트가 모두 이탈해 아무도 신고하지 않는 경우의 안전망이다. `matching:matched`
+ZSET 인덱스를 주기적으로 훑어 위와 같은 기준으로 `FAILED(SESSION_LOST)` 전환과 `markOnline`을
+수행한다. 호스트가 한 번 응답하지 않았다는 이유로 세션을 끝내지 않고, `ServerHealthRegistry`가
+`gameserver.failure-threshold`회 연속 실패로 서버를 로테이션에서 뺀 뒤에야 확정한다.
+
+| 설정 | 기본값 | 설명 |
+|---|---|---|
+| `matching.ticket.matched-scan-interval` | `30s` | 전체 스캔 주기. 세션 수명보다 훨씬 크게 잡으면 사실상 비활성화된다 |
+| `matching.ticket.pending-scan-interval` | `3s` | 신고됐지만 판정하지 못한 ticket의 재확인 주기 |
+| `matching.ticket.matched-scan-grace` | `30s` | `MATCHED`가 된 뒤 이 시간이 지나야 감사 대상이 된다 |
+| `matching.ticket.matched-scan-batch-size` | `100` | 한 번의 스캔에서 감사할 ticket 수 |
+
+## 게임 서버 연동
+
+게임 서버의 `POST /api/server/game-sessions` 응답(`SessionReadyResponse`)에 `instanceId`가
+추가됐다. 프로세스 부팅마다 새로 생성되는 UUID이며, 게임 서버가 `public.servers.instance_id`
+(`VARCHAR(64)`, nullable, migration `V041_20260810__add_server_instance_id.sql`)에도 같은 값을 쓴다.
+로비는 매칭 시점의 값을 ticket에 보관했다가 현재 값과 비교해 호스트 재시작을 판별한다.
+`NULL`은 "아직 보고되지 않음"이며 재시작 증거가 아니다.

--- a/src/main/kotlin/com/wordonline/matching/matching/config/MatchTicketProperties.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/config/MatchTicketProperties.kt
@@ -7,5 +7,30 @@ import java.time.Duration
 data class MatchTicketProperties(
     val queueTimeout: Duration = Duration.ofMinutes(5),
     val allocationLease: Duration = Duration.ofSeconds(30),
+    /**
+     * How long a finished ticket stays readable so a reconnecting client can still see why
+     * it ended. Only terminal tickets carry it; a `MATCHED` ticket must never expire while
+     * its session is running.
+     */
     val terminalTtl: Duration = Duration.ofMinutes(30),
+    /**
+     * How often the reconciler sweeps `MATCHED` tickets looking for sessions whose host
+     * process is gone. Raising it far above a session's lifetime effectively disables the
+     * sweep without a code change.
+     */
+    val matchedScanInterval: Duration = Duration.ofSeconds(30),
+    /**
+     * How often the reconciler re-checks tickets a client already reported but the lobby
+     * could not verify. Much shorter than [matchedScanInterval] because such a ticket stays
+     * `MATCHED`, and the client keeps re-entering the game scene until the verdict lands.
+     */
+    val pendingScanInterval: Duration = Duration.ofSeconds(3),
+    /**
+     * Grace period after a ticket reaches `MATCHED` before the reconciler will audit it.
+     * Guards against auditing a session the game server has accepted but not yet finished
+     * registering, which would answer `active=false` and look like a loss.
+     */
+    val matchedScanGrace: Duration = Duration.ofSeconds(30),
+    /** Tickets audited per sweep, so one sweep cannot fan out unboundedly. */
+    val matchedScanBatchSize: Long = 100,
 )

--- a/src/main/kotlin/com/wordonline/matching/matching/controller/MatchingController.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/controller/MatchingController.kt
@@ -5,10 +5,13 @@ import com.wordonline.matching.matching.dto.MatchedInfoDto
 import com.wordonline.matching.matching.dto.QueueLengthResponseDto
 import com.wordonline.matching.matching.dto.SimpleMessageDto
 import com.wordonline.matching.matching.service.GameMatchService
+import com.wordonline.matching.matching.service.SessionLostReportService
 import com.wordonline.matching.matching.domain.CancelMatchResponse
 import com.wordonline.matching.matching.domain.MatchTicket
+import com.wordonline.matching.matching.domain.SessionLostReport
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.codec.ServerSentEvent
 import org.springframework.http.ResponseEntity
@@ -21,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class MatchingController(
     private val gameMatchService: GameMatchService,
+    private val sessionLostReportService: SessionLostReportService,
 ) {
     @GetMapping("/api/match/practice/me")
     suspend fun matchPractice(@UserId userId: Long?): MatchedInfoDto {
@@ -57,6 +61,28 @@ class MatchingController(
     suspend fun getActiveTicket(@UserId userId: Long?): ResponseEntity<MatchTicket> {
         val ticket = gameMatchService.getActiveTicket(userId!!)
         return if (ticket == null) ResponseEntity.notFound().build() else ResponseEntity.ok(ticket)
+    }
+
+    /**
+     * Reports that the client can no longer reach its session.
+     *
+     * Session-scoped rather than ticket-scoped because the client comes through the legacy
+     * match flow and holds a `sessionId` but no `ticketId`.
+     *
+     * - `200` the ticket is released, or there was nothing to release
+     * - `409` the session is still running; the returned snapshot is the live ticket
+     * - `404` no active ticket, or it belongs to a different session
+     * - `503` the host did not answer, so nothing is proven and the ticket is left alone
+     */
+    @PostMapping("/api/match/sessions/{sessionId}/report-lost")
+    suspend fun reportSessionLost(
+        @UserId userId: Long?,
+        @PathVariable sessionId: String,
+    ): ResponseEntity<MatchTicket> = when (val report = sessionLostReportService.report(userId!!, sessionId)) {
+        is SessionLostReport.Released -> ResponseEntity.ok(report.ticket)
+        is SessionLostReport.NothingToRelease -> ResponseEntity.ok(report.ticket)
+        is SessionLostReport.SessionAlive -> ResponseEntity.status(HttpStatus.CONFLICT).body(report.ticket)
+        SessionLostReport.UnknownSession -> ResponseEntity.notFound().build()
     }
 
     @GetMapping("/api/match/events", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])

--- a/src/main/kotlin/com/wordonline/matching/matching/domain/MatchTicket.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/domain/MatchTicket.kt
@@ -1,5 +1,6 @@
 package com.wordonline.matching.matching.domain
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.wordonline.matching.matching.dto.MatchedInfoDto
 import java.time.Instant
 
@@ -10,6 +11,15 @@ enum class MatchTicketState {
     CANCELED,
     EXPIRED,
     FAILED,
+    ;
+
+    /**
+     * A terminal ticket is finished for good: it is the only kind that may expire and the
+     * only kind that releases `matching:active:<userId>`. `MATCHED` is deliberately not
+     * terminal - a session outliving the terminal TTL must keep its ticket.
+     */
+    val isTerminal: Boolean
+        get() = this == CANCELED || this == EXPIRED || this == FAILED
 }
 
 data class MatchTicket(
@@ -22,9 +32,33 @@ data class MatchTicket(
     val matchInfo: MatchedInfoDto? = null,
     val attemptId: String? = null,
     val allocationLeaseUntil: Instant? = null,
+    /** `servers.id` of the game server that accepted this session, for health lookups. */
+    val serverId: Long? = null,
+    /**
+     * Boot generation of the game server process that accepted this session.
+     *
+     * A value differing from the current `servers.instance_id` proves the hosting process
+     * restarted and took the in-memory session with it. `null` on either side is "not
+     * reported", never "restarted".
+     */
+    val serverInstanceId: String? = null,
     val createdAt: Instant,
     val updatedAt: Instant,
-)
+) {
+    /**
+     * The other side of a PVP session, or `null` for bot/PVE sessions and unmatched tickets.
+     *
+     * `@JsonIgnore` because it is derived: without it the value would be written into the
+     * redis payload and the client-facing ticket JSON as if it were stored state.
+     */
+    @get:JsonIgnore
+    val opponentUserId: Long?
+        get() {
+            val info = matchInfo ?: return null
+            val opponent = if (info.leftUser.id() == userId) info.rightUser.id() else info.leftUser.id()
+            return opponent.takeIf { it > 0 && it != userId }
+        }
+}
 
 enum class CancelMatchResult {
     CANCELED,

--- a/src/main/kotlin/com/wordonline/matching/matching/domain/SessionLiveness.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/domain/SessionLiveness.kt
@@ -1,0 +1,14 @@
+package com.wordonline.matching.matching.domain
+
+/**
+ * What the lobby could establish about the session behind a `MATCHED` ticket.
+ *
+ * [UNKNOWN] is a first-class answer, not a failure to be folded into [LOST]. A game server
+ * that does not answer says nothing about whether its sessions are still running, and
+ * treating silence as proof of loss would end live matches during a network blip.
+ */
+enum class SessionLiveness {
+    ALIVE,
+    LOST,
+    UNKNOWN,
+}

--- a/src/main/kotlin/com/wordonline/matching/matching/domain/SessionLostReport.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/domain/SessionLostReport.kt
@@ -1,0 +1,21 @@
+package com.wordonline.matching.matching.domain
+
+/**
+ * Outcome of a client's "my session is gone" report.
+ *
+ * Modelled as a closed set so the controller maps every case to a status explicitly and a
+ * new outcome cannot silently default to `200`.
+ */
+sealed interface SessionLostReport {
+    /** The session was confirmed gone; the ticket is now `FAILED(SESSION_LOST)`. */
+    data class Released(val ticket: MatchTicket) : SessionLostReport
+
+    /** The session is still running. The ticket stays as it is. */
+    data class SessionAlive(val ticket: MatchTicket) : SessionLostReport
+
+    /** The ticket is not `MATCHED`, so the caller is already free. */
+    data class NothingToRelease(val ticket: MatchTicket) : SessionLostReport
+
+    /** No active ticket, or it belongs to a different session than the one reported. */
+    data object UnknownSession : SessionLostReport
+}

--- a/src/main/kotlin/com/wordonline/matching/matching/repository/MatchTicketRepository.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/repository/MatchTicketRepository.kt
@@ -28,6 +28,26 @@ class MatchTicketRepository(
         private const val TICKET_PREFIX = "matching:ticket:"
         private const val EVENT_PREFIX = "matching:events:"
         private const val LEASE_KEY = "matching:allocation-leases"
+
+        /**
+         * Index of tickets currently in `MATCHED`, scored by the instant they got there.
+         * Without it there is no way to iterate live sessions, so a game server that
+         * restarted left both tickets stuck with nobody watching them.
+         */
+        const val MATCHED_KEY = "matching:matched"
+
+        /**
+         * Tickets a client reported as lost that the lobby could not verify yet, scored by
+         * the time of the report.
+         *
+         * A deferred verdict leaves the ticket `MATCHED`, and the client re-enters the game
+         * scene on any `MATCHED` snapshot, so it bounces between lobby and game until the
+         * verdict lands. Waiting a full sweep for that is the difference between a couple of
+         * bounces and a couple of dozen; the reconciler drains this set on a much shorter
+         * schedule. It changes only how soon a session is re-probed, never what counts as
+         * proof that it ended.
+         */
+        const val PENDING_VERIFICATION_KEY = "matching:matched:pending"
     }
 
     private val enqueueScript = DefaultRedisScript(ENQUEUE_SCRIPT, String::class.java)
@@ -63,8 +83,17 @@ class MatchTicketRepository(
     suspend fun transition(ticket: MatchTicket, expected: MatchTicketState): MatchTicket? {
         val result = redis.execute(
             transitionScript,
-            listOf(ticketKey(ticket.ticketId), eventKey(ticket.userId), LEASE_KEY, QUEUE_KEY),
-            listOf(expected.name, encode(ticket), ticket.ticketId, properties.terminalTtl.toMillis().toString(), ticket.state.name, ticket.userId.toString(), ticket.updatedAt.toEpochMilli().toString()),
+            listOf(ticketKey(ticket.ticketId), eventKey(ticket.userId), LEASE_KEY, QUEUE_KEY, activeKey(ticket.userId), MATCHED_KEY),
+            listOf(
+                expected.name,
+                encode(ticket),
+                ticket.ticketId,
+                properties.terminalTtl.toMillis().toString(),
+                ticket.state.name,
+                ticket.userId.toString(),
+                ticket.updatedAt.toEpochMilli().toString(),
+                ticket.state.isTerminal.toString(),
+            ),
         ).next().awaitSingleOrNull()
         return result?.takeIf { it.isNotEmpty() }?.let(::decode)
     }
@@ -72,8 +101,30 @@ class MatchTicketRepository(
     suspend fun transitionPair(first: MatchTicket, second: MatchTicket, expected: MatchTicketState): Boolean {
         val result = redis.execute(
             transitionPairScript,
-            listOf(ticketKey(first.ticketId), ticketKey(second.ticketId), eventKey(first.userId), eventKey(second.userId), LEASE_KEY),
-            listOf(expected.name, encode(first), encode(second), first.ticketId, second.ticketId, properties.terminalTtl.toMillis().toString()),
+            listOf(
+                ticketKey(first.ticketId),
+                ticketKey(second.ticketId),
+                eventKey(first.userId),
+                eventKey(second.userId),
+                LEASE_KEY,
+                activeKey(first.userId),
+                activeKey(second.userId),
+                MATCHED_KEY,
+                QUEUE_KEY,
+            ),
+            listOf(
+                expected.name,
+                encode(first),
+                encode(second),
+                first.ticketId,
+                second.ticketId,
+                properties.terminalTtl.toMillis().toString(),
+                first.state.name,
+                first.userId.toString(),
+                second.userId.toString(),
+                first.updatedAt.toEpochMilli().toString(),
+                first.state.isTerminal.toString(),
+            ),
         ).next().awaitSingle()
         return result == 1L
     }
@@ -104,6 +155,54 @@ class MatchTicketRepository(
         val cutoff = Instant.now(clock).minus(properties.queueTimeout).toEpochMilli().toDouble()
         val ids = redis.opsForZSet().rangeByScore(QUEUE_KEY, Range.closed(Double.NEGATIVE_INFINITY, cutoff)).collectList().awaitSingle()
         return ids.mapNotNull { getActive(it.toLong()) }.filter { it.state == MatchTicketState.QUEUED }
+    }
+
+    /**
+     * Oldest `MATCHED` tickets first, skipping anything that reached `MATCHED` more recently
+     * than [settledBefore].
+     *
+     * Index entries whose ticket key is gone, or whose ticket has since moved on, are pruned
+     * here: nothing else would ever remove them once a ticket key expires.
+     */
+    suspend fun settledMatched(settledBefore: Instant, limit: Long): List<MatchTicket> =
+        stillMatched(MATCHED_KEY, settledBefore.toEpochMilli().toDouble(), limit)
+
+    /** Records that a reported ticket could not be verified yet, for a fast re-check. */
+    suspend fun markPendingVerification(ticketId: String, reportedAt: Instant) {
+        redis.opsForZSet().add(PENDING_VERIFICATION_KEY, ticketId, reportedAt.toEpochMilli().toDouble()).awaitSingleOrNull()
+    }
+
+    suspend fun clearPendingVerification(ticketId: String) {
+        redis.opsForZSet().remove(PENDING_VERIFICATION_KEY, ticketId).awaitSingleOrNull()
+    }
+
+    /** Reported-but-unverified tickets, oldest report first. No grace period: they were reported. */
+    suspend fun pendingVerification(limit: Long): List<MatchTicket> =
+        stillMatched(PENDING_VERIFICATION_KEY, Double.POSITIVE_INFINITY, limit)
+
+    /**
+     * Reads an index of ticket ids and drops the entries that no longer name a `MATCHED`
+     * ticket. Nothing else prunes them once a ticket key expires.
+     */
+    private suspend fun stillMatched(indexKey: String, maxScore: Double, limit: Long): List<MatchTicket> {
+        val ids = redis.opsForZSet()
+            .rangeByScore(
+                indexKey,
+                Range.closed(Double.NEGATIVE_INFINITY, maxScore),
+                org.springframework.data.redis.connection.Limit.limit().count(limit.toInt()),
+            )
+            .collectList()
+            .awaitSingle()
+
+        return ids.mapNotNull { ticketId ->
+            val ticket = redis.opsForValue().get(ticketKey(ticketId)).awaitSingleOrNull()?.let(::decode)
+            if (ticket == null || ticket.state != MatchTicketState.MATCHED) {
+                redis.opsForZSet().remove(indexKey, ticketId).awaitSingleOrNull()
+                null
+            } else {
+                ticket
+            }
+        }
     }
 
     fun events(userId: Long) = redis.listenToChannel(eventKey(userId))
@@ -144,13 +243,26 @@ redis.call('PUBLISH', KEYS[4], ARGV[1]); redis.call('PUBLISH', KEYS[5], ARGV[2])
 return 1
 """
 
+/**
+ * KEYS: ticket, events, leases, queue, active, matched-index.
+ * ARGV: expected state, payload, ticketId, terminalTtlMs, new state, userId, updatedAtMs, terminal flag.
+ *
+ * `SET` without `PX` clears any TTL left over from an earlier state, and the expiry is
+ * re-applied only for terminal states - a `MATCHED` ticket must outlive `terminalTtl`.
+ * The active pointer is released by compare-and-delete so a user who already re-queued
+ * keeps the newer ticket.
+ */
 private const val TRANSITION_SCRIPT = """
 local current = redis.call('GET', KEYS[1])
 if not current or cjson.decode(current).state ~= ARGV[1] then return '' end
 redis.call('SET', KEYS[1], ARGV[2]); redis.call('ZREM', KEYS[3], ARGV[3])
 redis.call('PUBLISH', KEYS[2], ARGV[2])
-if ARGV[5] ~= 'QUEUED' and ARGV[5] ~= 'ALLOCATING' then redis.call('ZREM', KEYS[4], ARGV[6]); redis.call('PEXPIRE', KEYS[1], ARGV[4]) end
-if ARGV[5] == 'QUEUED' then redis.call('ZADD', KEYS[4], ARGV[7], ARGV[6]) end
+if ARGV[5] == 'QUEUED' then redis.call('ZADD', KEYS[4], ARGV[7], ARGV[6]) else redis.call('ZREM', KEYS[4], ARGV[6]) end
+if ARGV[5] == 'MATCHED' then redis.call('ZADD', KEYS[6], ARGV[7], ARGV[3]) else redis.call('ZREM', KEYS[6], ARGV[3]) end
+if ARGV[8] == 'true' then
+  redis.call('PEXPIRE', KEYS[1], ARGV[4])
+  if redis.call('GET', KEYS[5]) == ARGV[3] then redis.call('DEL', KEYS[5]) end
+end
 return ARGV[2]
 """
 
@@ -162,16 +274,36 @@ local ticket = cjson.decode(raw)
 if ticket.state == 'QUEUED' then
  ticket.state = 'CANCELED'; ticket.reason = 'USER_REQUESTED'; ticket.version = ticket.version + 1; ticket.updatedAt = ARGV[3]
  local updated = cjson.encode(ticket); redis.call('SET', key, updated); redis.call('ZREM', KEYS[2], ARGV[2]); redis.call('ZREM', KEYS[4], id)
- redis.call('PUBLISH', KEYS[3], updated); redis.call('PEXPIRE', key, ARGV[4]); return updated
+ redis.call('PUBLISH', KEYS[3], updated); redis.call('PEXPIRE', key, ARGV[4]); redis.call('DEL', KEYS[1]); return updated
 end
 return raw
 """
 
+/**
+ * KEYS: first ticket, second ticket, first events, second events, leases,
+ *       first active, second active, matched-index, queue.
+ * ARGV: expected state, first payload, second payload, first ticketId, second ticketId,
+ *       terminalTtlMs, new state, first userId, second userId, updatedAtMs, terminal flag.
+ *
+ * The unconditional `SET ... 'PX'` this replaces silently expired `MATCHED` tickets after
+ * `terminalTtl`, killing the ticket of any session that ran longer than 30 minutes.
+ */
 private const val TRANSITION_PAIR_SCRIPT = """
 local first = redis.call('GET', KEYS[1]); local second = redis.call('GET', KEYS[2])
 if not first or not second or cjson.decode(first).state ~= ARGV[1] or cjson.decode(second).state ~= ARGV[1] then return 0 end
-redis.call('SET', KEYS[1], ARGV[2], 'PX', ARGV[6]); redis.call('SET', KEYS[2], ARGV[3], 'PX', ARGV[6])
+redis.call('SET', KEYS[1], ARGV[2]); redis.call('SET', KEYS[2], ARGV[3])
 redis.call('ZREM', KEYS[5], ARGV[4], ARGV[5])
+redis.call('ZREM', KEYS[9], ARGV[8], ARGV[9])
+if ARGV[7] == 'MATCHED' then
+  redis.call('ZADD', KEYS[8], ARGV[10], ARGV[4], ARGV[10], ARGV[5])
+else
+  redis.call('ZREM', KEYS[8], ARGV[4], ARGV[5])
+end
+if ARGV[11] == 'true' then
+  redis.call('PEXPIRE', KEYS[1], ARGV[6]); redis.call('PEXPIRE', KEYS[2], ARGV[6])
+  if redis.call('GET', KEYS[6]) == ARGV[4] then redis.call('DEL', KEYS[6]) end
+  if redis.call('GET', KEYS[7]) == ARGV[5] then redis.call('DEL', KEYS[7]) end
+end
 redis.call('PUBLISH', KEYS[3], ARGV[2]); redis.call('PUBLISH', KEYS[4], ARGV[3])
 return 1
 """

--- a/src/main/kotlin/com/wordonline/matching/matching/service/GameMatchService.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/service/GameMatchService.kt
@@ -49,19 +49,19 @@ class GameMatchService(
         val sessionId = "bot-${matchingQueueRepository.nextSessionId().awaitSingle()}"
         val botId = botMemberMaker.getRandomEnabledBotId().awaitSingle()
         val sessionDto = SessionDto.Practice(sessionId, userId, botId)
-        return legacyGameMatchService.createSession(sessionDto)
+        return legacyGameMatchService.createSession(sessionDto).matchInfo
     }
 
     suspend fun matchBots(leftBotId: Long, rightBotId: Long): MatchedInfoDto {
         val sessionId = "admin-bot-${matchingQueueRepository.nextSessionId().awaitSingle()}"
         val sessionDto = SessionDto.Practice(sessionId, leftBotId, rightBotId)
-        return legacyGameMatchService.createSession(sessionDto)
+        return legacyGameMatchService.createSession(sessionDto).matchInfo
     }
 
     suspend fun matchPVE(userId: Long, scenarioId: Long): MatchedInfoDto {
         val sessionId = "pve-${matchingQueueRepository.nextSessionId().awaitSingle()}"
         val sessionDto = SessionDto.PVE(sessionId, userId, scenarioId)
-        return legacyGameMatchService.createSession(sessionDto)
+        return legacyGameMatchService.createSession(sessionDto).matchInfo
     }
 
     suspend fun match(userId: Long): SimpleMessageDto {
@@ -150,11 +150,29 @@ class GameMatchService(
             val sessionDto = SessionDto.from(sessionId, uid1, uid2)
 
             try {
-                val matchInfo = legacyGameMatchService.createSession(sessionDto, attemptId)
+                val placement = legacyGameMatchService.createSession(sessionDto, attemptId)
                 val matchedAt = Instant.now(clock)
+                // The host's boot generation rides on the ticket: it is the only way to tell
+                // later that the process holding this in-memory session was replaced.
                 val completed = matchTicketRepository.transitionPair(
-                    first.copy(state = MatchTicketState.MATCHED, version = first.version + 1, matchInfo = matchInfo, allocationLeaseUntil = null, updatedAt = matchedAt),
-                    second.copy(state = MatchTicketState.MATCHED, version = second.version + 1, matchInfo = matchInfo, allocationLeaseUntil = null, updatedAt = matchedAt),
+                    first.copy(
+                        state = MatchTicketState.MATCHED,
+                        version = first.version + 1,
+                        matchInfo = placement.matchInfo,
+                        serverId = placement.serverId,
+                        serverInstanceId = placement.serverInstanceId,
+                        allocationLeaseUntil = null,
+                        updatedAt = matchedAt,
+                    ),
+                    second.copy(
+                        state = MatchTicketState.MATCHED,
+                        version = second.version + 1,
+                        matchInfo = placement.matchInfo,
+                        serverId = placement.serverId,
+                        serverInstanceId = placement.serverInstanceId,
+                        allocationLeaseUntil = null,
+                        updatedAt = matchedAt,
+                    ),
                     MatchTicketState.ALLOCATING,
                 )
                 check(completed) { "Match tickets changed before completion: attemptId=$attemptId" }

--- a/src/main/kotlin/com/wordonline/matching/matching/service/LostSessionRecovery.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/service/LostSessionRecovery.kt
@@ -1,0 +1,87 @@
+package com.wordonline.matching.matching.service
+
+import com.wordonline.matching.auth.service.UserService
+import com.wordonline.matching.matching.domain.MatchTicket
+import com.wordonline.matching.matching.domain.MatchTicketState
+import com.wordonline.matching.matching.repository.MatchTicketRepository
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.time.Clock
+import java.time.Instant
+
+/**
+ * Retires the tickets of a session that is confirmed gone.
+ *
+ * Both players are stuck by the same missing session, and only one of them may ever report
+ * it, so releasing one side alone would leave the other unable to re-queue. The opponent is
+ * only touched while their active ticket still points at *this* session: once they have a
+ * fresh ticket, a late report about the old session must not disturb it.
+ */
+@Service
+class LostSessionRecovery(
+    private val matchTicketRepository: MatchTicketRepository,
+    private val userService: UserService,
+) {
+    companion object {
+        const val SESSION_LOST_REASON = "SESSION_LOST"
+    }
+
+    private val clock = Clock.systemUTC()
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * Transitions [ticket] - and the opponent's ticket when it qualifies - to
+     * `FAILED(SESSION_LOST)`, then puts the released users back online.
+     *
+     * Returns the caller's ticket as it now stands. A `null` return means the ticket moved
+     * on under us and nothing was changed.
+     */
+    suspend fun release(ticket: MatchTicket): MatchTicket? {
+        val now = Instant.now(clock)
+        val failed = ticket.toLost(now)
+        val opponent = findOpponentOnSameSession(ticket)
+
+        if (opponent != null && matchTicketRepository.transitionPair(failed, opponent.toLost(now), MatchTicketState.MATCHED)) {
+            log.info(
+                "Released both tickets of lost session: sessionId={}, userIds=[{}, {}]",
+                ticket.matchInfo?.sessionId,
+                ticket.userId,
+                opponent.userId,
+            )
+            markOnline(ticket.userId)
+            markOnline(opponent.userId)
+            return failed
+        }
+
+        // Either there was no opponent to release, or their ticket changed between the read
+        // and the write. The reporter still has to be freed.
+        val released = matchTicketRepository.transition(failed, MatchTicketState.MATCHED) ?: return null
+        log.info("Released ticket of lost session: sessionId={}, userId={}", ticket.matchInfo?.sessionId, ticket.userId)
+        markOnline(ticket.userId)
+        return released
+    }
+
+    private suspend fun findOpponentOnSameSession(ticket: MatchTicket): MatchTicket? {
+        val sessionId = ticket.matchInfo?.sessionId ?: return null
+        val opponentUserId = ticket.opponentUserId ?: return null
+        val opponent = matchTicketRepository.getActive(opponentUserId) ?: return null
+        val onSameSession = opponent.state == MatchTicketState.MATCHED &&
+            opponent.ticketId != ticket.ticketId &&
+            opponent.matchInfo?.sessionId == sessionId
+        return opponent.takeIf { onSameSession }
+    }
+
+    private fun MatchTicket.toLost(now: Instant) = copy(
+        state = MatchTicketState.FAILED,
+        version = version + 1,
+        reason = SESSION_LOST_REASON,
+        attemptId = null,
+        allocationLeaseUntil = null,
+        updatedAt = now,
+    )
+
+    private suspend fun markOnline(userId: Long) {
+        userService.markOnline(userId).awaitSingleOrNull()
+    }
+}

--- a/src/main/kotlin/com/wordonline/matching/matching/service/MatchedTicketReconciler.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/service/MatchedTicketReconciler.kt
@@ -1,0 +1,122 @@
+package com.wordonline.matching.matching.service
+
+import com.wordonline.matching.matching.config.MatchTicketProperties
+import com.wordonline.matching.matching.domain.MatchTicket
+import com.wordonline.matching.matching.domain.SessionLiveness
+import com.wordonline.matching.matching.repository.MatchTicketRepository
+import com.wordonline.matching.server.service.ServerHealthRegistry
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.time.Clock
+import java.time.Instant
+
+/**
+ * Safety net for `MATCHED` tickets nobody reports.
+ *
+ * A client report clears the common case, but when both players quit the game there is
+ * nobody left to tell the lobby that the session died with its host, and the ticket would
+ * block re-queueing forever.
+ *
+ * The sweep confirms a loss only on evidence:
+ *
+ * - [SessionLiveness.LOST] - the host answered "no such session", or its boot generation
+ *   changed. Conclusive on its own.
+ * - [SessionLiveness.UNKNOWN] - the host said nothing. Confirmed only once
+ *   [ServerHealthRegistry] has already taken that server out of rotation, which takes
+ *   `gameserver.failure-threshold` consecutive failed probes. That reuse is deliberate: a
+ *   single missed probe must never end a live match, and duplicating a second failure
+ *   counter here would just be a second thing to tune wrong.
+ */
+@Service
+class MatchedTicketReconciler(
+    private val matchTicketRepository: MatchTicketRepository,
+    private val sessionLivenessProbe: SessionLivenessProbe,
+    private val lostSessionRecovery: LostSessionRecovery,
+    private val serverHealthRegistry: ServerHealthRegistry,
+    private val properties: MatchTicketProperties,
+) {
+    private val clock = Clock.systemUTC()
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        log.error("Unexpected error while reconciling matched tickets", throwable)
+    }
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default + exceptionHandler)
+
+    /** `@Scheduled` cannot invoke a suspend function, so the annotated method only launches. */
+    @Scheduled(fixedDelayString = "\${matching.ticket.matched-scan-interval}")
+    fun scan() {
+        scope.launch { reconcile() }
+    }
+
+    /**
+     * Fast lane for tickets a client already reported and the lobby could not verify.
+     *
+     * No grace period here: the ticket was reported, and the same verdict rules still decide
+     * the outcome. Only the waiting time changes.
+     */
+    @Scheduled(fixedDelayString = "\${matching.ticket.pending-scan-interval}")
+    fun drainPendingVerification() {
+        scope.launch { reconcilePending() }
+    }
+
+    suspend fun reconcile() {
+        val settledBefore = Instant.now(clock).minus(properties.matchedScanGrace)
+        audit(matchTicketRepository.settledMatched(settledBefore, properties.matchedScanBatchSize))
+    }
+
+    suspend fun reconcilePending() {
+        val tickets = matchTicketRepository.pendingVerification(properties.matchedScanBatchSize)
+        if (tickets.isEmpty()) return
+        for (ticket in audit(tickets)) {
+            matchTicketRepository.clearPendingVerification(ticket.ticketId)
+        }
+    }
+
+    /** Returns the tickets that reached a verdict, whether the session was alive or gone. */
+    private suspend fun audit(tickets: List<MatchTicket>): List<MatchTicket> {
+        val handledSessions = mutableSetOf<String>()
+        val decided = mutableListOf<MatchTicket>()
+
+        for (ticket in tickets) {
+            val sessionId = ticket.matchInfo?.sessionId ?: continue
+            // Both tickets of a pair sit next to each other in the index and are retired
+            // together, so the second one would only re-probe a host we already asked.
+            if (!handledSessions.add(sessionId)) continue
+
+            when (sessionLivenessProbe.check(ticket)) {
+                SessionLiveness.ALIVE -> decided += ticket
+                SessionLiveness.LOST -> decided += release(ticket, sessionId)
+                SessionLiveness.UNKNOWN -> if (isHostOutOfRotation(ticket)) decided += release(ticket, sessionId)
+            }
+        }
+        return decided
+    }
+
+    private suspend fun release(ticket: MatchTicket, sessionId: String): MatchTicket {
+        lostSessionRecovery.release(ticket)?.also {
+            log.warn(
+                "Reconciled lost session: ticketId={}, sessionId={}, userId={}",
+                ticket.ticketId,
+                sessionId,
+                ticket.userId,
+            )
+        }
+        return ticket
+    }
+
+    /**
+     * A host is only "gone" once the health registry says so. An unresolvable server row
+     * stays inconclusive: without health history there is no hysteresis to lean on, and
+     * guessing would risk ending a live session.
+     */
+    private fun isHostOutOfRotation(ticket: MatchTicket): Boolean {
+        val serverId = sessionLivenessProbe.hostOf(ticket)?.id ?: return false
+        return !serverHealthRegistry.isHealthy(serverId)
+    }
+}

--- a/src/main/kotlin/com/wordonline/matching/matching/service/SessionLivenessProbe.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/service/SessionLivenessProbe.kt
@@ -1,0 +1,80 @@
+package com.wordonline.matching.matching.service
+
+import com.wordonline.matching.matching.domain.MatchTicket
+import com.wordonline.matching.matching.domain.SessionLiveness
+import com.wordonline.matching.server.entity.Server
+import com.wordonline.matching.server.exception.GameServerUnreachableException
+import com.wordonline.matching.server.service.ServerHealthRegistry
+import com.wordonline.matching.session.service.LegacyGameMatchService
+import kotlinx.coroutines.CancellationException
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+/**
+ * Decides whether the session behind a `MATCHED` ticket still exists.
+ *
+ * Two independent signals, cheapest first:
+ *
+ * 1. Boot generation. A game server keeps its sessions in memory only, so a process that
+ *    restarted took them with it. The id the ticket recorded at match time versus the id
+ *    the server row publishes now proves that without any network call - and it stays
+ *    correct even when the restarted process is already answering health checks again.
+ * 2. Session query against the hosting server. Authoritative when the host answers.
+ *
+ * Every inconclusive path collapses to [SessionLiveness.UNKNOWN]. A missing id on either
+ * side is an older game server build, not evidence of a restart.
+ */
+@Component
+class SessionLivenessProbe(
+    private val legacyGameMatchService: LegacyGameMatchService,
+    private val serverHealthRegistry: ServerHealthRegistry,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    suspend fun check(ticket: MatchTicket): SessionLiveness {
+        val matchInfo = ticket.matchInfo ?: return SessionLiveness.UNKNOWN
+
+        if (hasRestarted(ticket)) {
+            log.info(
+                "Host process restarted since match: ticketId={}, sessionId={}, ticketInstanceId={}",
+                ticket.ticketId,
+                matchInfo.sessionId,
+                ticket.serverInstanceId,
+            )
+            return SessionLiveness.LOST
+        }
+
+        return try {
+            if (legacyGameMatchService.isSessionActive(matchInfo.server, matchInfo.sessionId)) {
+                SessionLiveness.ALIVE
+            } else {
+                SessionLiveness.LOST
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: GameServerUnreachableException) {
+            log.warn("Host {} did not answer about session {}", matchInfo.server, matchInfo.sessionId, e)
+            SessionLiveness.UNKNOWN
+        }
+    }
+
+    /** Conclusive only when both sides reported an id and the ids differ. */
+    private fun hasRestarted(ticket: MatchTicket): Boolean {
+        val recorded = ticket.serverInstanceId ?: return false
+        val current = hostOf(ticket)?.instanceId ?: return false
+        return recorded != current
+    }
+
+    /**
+     * The server row hosting this ticket's session.
+     *
+     * Matched by id first, which is what the ticket records at match time. The URL fallback
+     * covers tickets written before [MatchTicket.serverId] existed.
+     */
+    fun hostOf(ticket: MatchTicket): Server? {
+        val servers = serverHealthRegistry.servers
+        ticket.serverId?.let { id -> servers.firstOrNull { it.id == id }?.let { return it } }
+        val hostUrl = ticket.matchInfo?.server ?: return null
+        return servers.firstOrNull { runCatching { it.url }.getOrNull() == hostUrl }
+    }
+}

--- a/src/main/kotlin/com/wordonline/matching/matching/service/SessionLostReportService.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/service/SessionLostReportService.kt
@@ -1,0 +1,90 @@
+package com.wordonline.matching.matching.service
+
+import com.wordonline.matching.global.service.LocalizationService
+import com.wordonline.matching.matching.domain.MatchTicket
+import com.wordonline.matching.matching.domain.MatchTicketState
+import com.wordonline.matching.matching.domain.SessionLiveness
+import com.wordonline.matching.matching.domain.SessionLostReport
+import com.wordonline.matching.matching.repository.MatchTicketRepository
+import com.wordonline.matching.server.exception.GameServerUnreachableException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.reactor.ReactorContext
+import org.slf4j.LoggerFactory
+import org.springframework.context.i18n.LocaleContext
+import org.springframework.context.i18n.SimpleLocaleContext
+import org.springframework.stereotype.Service
+import java.time.Clock
+import java.time.Instant
+import java.util.Locale
+
+/**
+ * Handles `POST /api/match/sessions/{sessionId}/report-lost`.
+ *
+ * The report is a hint, never a verdict: a client can only tell the lobby *where* to look.
+ * Whether the session actually ended is decided by [SessionLivenessProbe] alone, so a
+ * malicious or merely disconnected client cannot end a match that is still running.
+ *
+ * The path is session-scoped because the client reaches a match through the legacy flow and
+ * holds a `sessionId` but no `ticketId`; the ticket is resolved here from the caller's id.
+ */
+@Service
+class SessionLostReportService(
+    private val matchTicketRepository: MatchTicketRepository,
+    private val sessionLivenessProbe: SessionLivenessProbe,
+    private val lostSessionRecovery: LostSessionRecovery,
+    private val localizationService: LocalizationService,
+) {
+    private val clock = Clock.systemUTC()
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    suspend fun report(userId: Long, sessionId: String): SessionLostReport {
+        val ticket = matchTicketRepository.getActive(userId)
+        if (ticket == null || ticket.matchInfo?.sessionId != sessionId) {
+            return SessionLostReport.UnknownSession
+        }
+        // Nothing to release: the caller is already free and just has stale local state.
+        if (ticket.state != MatchTicketState.MATCHED) {
+            return SessionLostReport.NothingToRelease(ticket)
+        }
+
+        return when (sessionLivenessProbe.check(ticket)) {
+            SessionLiveness.ALIVE -> {
+                matchTicketRepository.clearPendingVerification(ticket.ticketId)
+                SessionLostReport.SessionAlive(ticket)
+            }
+            SessionLiveness.UNKNOWN -> {
+                // Deferring the verdict leaves the ticket MATCHED, and the client re-enters
+                // the game scene on every MATCHED snapshot. Queue it for the fast re-check so
+                // that bounce lasts seconds rather than a whole scan interval.
+                matchTicketRepository.markPendingVerification(ticket.ticketId, Instant.now(clock))
+                throw GameServerUnreachableException(localizedMessage())
+            }
+            SessionLiveness.LOST -> released(ticket)
+        }
+    }
+
+    private suspend fun released(ticket: MatchTicket): SessionLostReport {
+        val released = lostSessionRecovery.release(ticket)
+        if (released == null) {
+            // The ticket changed under us; report whatever it is now rather than guessing.
+            log.info("Ticket moved on while releasing lost session: ticketId={}", ticket.ticketId)
+            val current = matchTicketRepository.getActive(ticket.userId)
+                ?: return SessionLostReport.UnknownSession
+            return SessionLostReport.NothingToRelease(current)
+        }
+        return SessionLostReport.Released(released)
+    }
+
+    /**
+     * Mirrors the locale handling of the legacy session flow: the request locale rides in the
+     * Reactor context, and its absence falls back to the default locale instead of throwing.
+     */
+    private suspend fun localizedMessage(): String {
+        val localeContext: LocaleContext = currentCoroutineContext()[ReactorContext]
+            ?.context
+            ?.getOrEmpty<LocaleContext>(LocaleContext::class.java)
+            ?.orElse(null)
+            ?: SimpleLocaleContext(Locale.getDefault())
+        return localizationService.getMessage(localeContext, "error.gameserver.unreachable")
+    }
+}

--- a/src/main/kotlin/com/wordonline/matching/server/entity/Server.kt
+++ b/src/main/kotlin/com/wordonline/matching/server/entity/Server.kt
@@ -11,6 +11,15 @@ data class Server(
     val port: Int? = null,
     val state: ServerState? = null,
     val type: ServerType? = null,
+    /**
+     * Boot generation the game server reports on every process start, written by the game
+     * server itself (`V041_20260810__add_server_instance_id.sql`).
+     *
+     * `null` means "not reported yet" - an older game server build - and never means
+     * "restarted". Comparisons against a ticket's stored value must stay inconclusive on
+     * `null` and fall back to querying session liveness.
+     */
+    val instanceId: String? = null,
 ) {
     val isLocal: Boolean
         get() = domain == "localhost" || domain == "127.0.0.1"

--- a/src/main/kotlin/com/wordonline/matching/session/domain/SessionPlacement.kt
+++ b/src/main/kotlin/com/wordonline/matching/session/domain/SessionPlacement.kt
@@ -1,0 +1,17 @@
+package com.wordonline.matching.session.domain
+
+import com.wordonline.matching.matching.dto.MatchedInfoDto
+
+/**
+ * Where a session actually landed.
+ *
+ * The client only ever needs [matchInfo], but recovering a lost session needs to know which
+ * game server row hosts it and which boot generation of that process accepted it. Those two
+ * stay off [MatchedInfoDto] on purpose: they are lobby bookkeeping, not something the client
+ * should see or be able to influence.
+ */
+data class SessionPlacement(
+    val matchInfo: MatchedInfoDto,
+    val serverId: Long?,
+    val serverInstanceId: String?,
+)

--- a/src/main/kotlin/com/wordonline/matching/session/dto/CreateSessionRequest.kt
+++ b/src/main/kotlin/com/wordonline/matching/session/dto/CreateSessionRequest.kt
@@ -27,4 +27,10 @@ data class SessionReadyResponse(
     val ready: Boolean,
     val serverUrl: String,
     val webSocketUrl: String,
+    /**
+     * Boot generation of the game server process that now owns this session. `null` when the
+     * game server predates the field; the lobby then has no restart evidence and must decide
+     * liveness from the session query alone.
+     */
+    val instanceId: String? = null,
 )

--- a/src/main/kotlin/com/wordonline/matching/session/service/LegacyGameMatchService.kt
+++ b/src/main/kotlin/com/wordonline/matching/session/service/LegacyGameMatchService.kt
@@ -9,6 +9,7 @@ import com.wordonline.matching.server.entity.Server
 import com.wordonline.matching.server.exception.GameServerUnreachableException
 import com.wordonline.matching.server.exception.NoAvailableGameServerException
 import com.wordonline.matching.server.service.GameServerManagementService
+import com.wordonline.matching.session.domain.SessionPlacement
 import com.wordonline.matching.session.domain.SessionRecoveryInfo
 import com.wordonline.matching.session.dto.SimpleBooleanDto
 import com.wordonline.matching.session.dto.CreateSessionRequest
@@ -54,7 +55,7 @@ class LegacyGameMatchService(
      * out. Looking the users up once outside the loop also keeps a failover from re-querying
      * the account server per candidate.
      */
-    suspend fun createSession(sessionDto: SessionDto, attemptId: String = UUID.randomUUID().toString()): MatchedInfoDto {
+    suspend fun createSession(sessionDto: SessionDto, attemptId: String = UUID.randomUUID().toString()): SessionPlacement {
         val candidates = gameServerManagementService.getAvailableServers()
         if (candidates.isEmpty()) {
             throw NoAvailableGameServerException(localizedMessage("error.gameserver.unavailable"))
@@ -76,7 +77,7 @@ class LegacyGameMatchService(
                 ready.webSocketUrl,
             )
             sessionRecoveryStore.storeMatchInfo(matchedInfo).awaitSingleOrNull()
-            return matchedInfo
+            return SessionPlacement(matchedInfo, server.id, ready.instanceId)
         }
 
         log.error(
@@ -117,7 +118,7 @@ class LegacyGameMatchService(
             ?: throw IllegalArgumentException("Session Not Found")
 
         // ask the server that hosts this session, not an arbitrary available one
-        if (!checkSessionActive(sessionInfo.serverUrl(), sessionInfo.sessionId())) {
+        if (!isSessionActive(sessionInfo.serverUrl(), sessionInfo.sessionId())) {
             throw IllegalArgumentException("Session Already Deactivated")
         }
 
@@ -129,7 +130,7 @@ class LegacyGameMatchService(
      * A host that does not answer is a transient failure, not proof the session ended, so
      * this throws [GameServerUnreachableException] instead of reporting the session gone.
      */
-    private suspend fun checkSessionActive(serverUrl: String, sessionId: String): Boolean =
+    suspend fun isSessionActive(serverUrl: String, sessionId: String): Boolean =
         try {
             webClientBuilder.baseUrl(serverUrl).build()
                 .get()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,11 +52,20 @@ jwt:
 deploy:
   type: ${DEPLOY_TYPE:DEV}
 
+# Bound to MatchTicketProperties.
 matching:
   ticket:
     queue-timeout: 5m
     allocation-lease: 30s
+    # Applies to terminal tickets only. A MATCHED ticket never expires while its session runs.
     terminal-ttl: 30m
+    # MATCHED reconciler. Raise the interval far above a session's lifetime to disable the sweep.
+    matched-scan-interval: ${MATCHING_MATCHED_SCAN_INTERVAL:30s}
+    # Fast re-check of tickets a client reported but the lobby could not verify yet.
+    pending-scan-interval: ${MATCHING_PENDING_SCAN_INTERVAL:3s}
+    # A ticket is audited only once it has been MATCHED for at least this long.
+    matched-scan-grace: ${MATCHING_MATCHED_SCAN_GRACE:30s}
+    matched-scan-batch-size: ${MATCHING_MATCHED_SCAN_BATCH_SIZE:100}
 
 # Bound to GameServerProperties.
 gameserver:

--- a/src/test/kotlin/com/wordonline/matching/matching/domain/MatchTicketSerializationTest.kt
+++ b/src/test/kotlin/com/wordonline/matching/matching/domain/MatchTicketSerializationTest.kt
@@ -33,15 +33,49 @@ class MatchTicketSerializationTest {
                 webSocketUrl = "http://localhost:7777/ws",
             ),
             attemptId = "attempt-1",
+            serverId = 7L,
+            serverInstanceId = "boot-1",
             createdAt = Instant.parse("2026-08-10T00:00:00Z"),
             updatedAt = Instant.parse("2026-08-10T00:00:05Z"),
         )
 
-        val decoded = objectMapper.readValue(objectMapper.writeValueAsString(ticket), MatchTicket::class.java)
+        val json = objectMapper.writeValueAsString(ticket)
+        val decoded = objectMapper.readValue(json, MatchTicket::class.java)
 
         assertThat(decoded).isEqualTo(ticket)
         assertThat(decoded.matchInfo?.server).isEqualTo("http://localhost:7777")
         assertThat(decoded.matchInfo?.webSocketUrl).isEqualTo("http://localhost:7777/ws")
+        assertThat(decoded.serverInstanceId)
+            .`as`("호스트 재시작 판별의 유일한 근거이므로 왕복에서 사라지면 안 된다")
+            .isEqualTo("boot-1")
+        assertThat(decoded.serverId).isEqualTo(7L)
+    }
+
+    @Test
+    fun `derived opponent id is not written into the payload`() {
+        // A derived value in the payload would be read back as stored state on the next
+        // decode and could contradict matchInfo after a re-match.
+        val ticket = MatchTicket(
+            ticketId = "ticket-3",
+            userId = 1L,
+            mmr = 1200L,
+            state = MatchTicketState.MATCHED,
+            version = 3L,
+            matchInfo = MatchedInfoDto(
+                message = "Successfully Matched",
+                server = "http://localhost:7777",
+                leftUser = UserDetailResponseDto(1L, "left", "left@example.com"),
+                rightUser = UserDetailResponseDto(2L, "right", "right@example.com"),
+                sessionId = "session-1",
+            ),
+            createdAt = Instant.parse("2026-08-10T00:00:00Z"),
+            updatedAt = Instant.parse("2026-08-10T00:00:05Z"),
+        )
+
+        val json = objectMapper.readTree(objectMapper.writeValueAsString(ticket))
+
+        assertThat(json.has("opponentUserId")).isFalse()
+        assertThat(ticket.opponentUserId).isEqualTo(2L)
     }
 
     @Test

--- a/src/test/kotlin/com/wordonline/matching/matching/repository/MatchTicketRepositoryScriptTest.kt
+++ b/src/test/kotlin/com/wordonline/matching/matching/repository/MatchTicketRepositoryScriptTest.kt
@@ -1,0 +1,222 @@
+package com.wordonline.matching.matching.repository
+
+import com.wordonline.matching.auth.dto.UserDetailResponseDto
+import com.wordonline.matching.matching.config.MatchTicketProperties
+import com.wordonline.matching.matching.domain.MatchTicket
+import com.wordonline.matching.matching.domain.MatchTicketState
+import com.wordonline.matching.matching.dto.MatchedInfoDto
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Redis-side behaviour of the ticket state machine, executed against the real Lua.
+ */
+class MatchTicketRepositoryScriptTest {
+
+    private val objectMapper = Jackson2ObjectMapperBuilder.json().build<com.fasterxml.jackson.databind.ObjectMapper>()
+    private val properties = MatchTicketProperties(terminalTtl = Duration.ofMinutes(30))
+    private val sandbox = RedisScriptSandbox()
+    private val repository = sandboxMatchTicketRepository(sandbox, properties)
+
+    private val matchedAt = Instant.parse("2026-08-10T00:00:00Z")
+
+    private fun matchInfo(sessionId: String = "session-1") = MatchedInfoDto(
+        message = "Successfully Matched",
+        server = "http://localhost:7777",
+        leftUser = UserDetailResponseDto(1L, "left", "left@team6515.com"),
+        rightUser = UserDetailResponseDto(2L, "right", "right@team6515.com"),
+        sessionId = sessionId,
+        webSocketUrl = "ws://localhost:7777/ws",
+    )
+
+    private fun ticket(
+        ticketId: String,
+        userId: Long,
+        state: MatchTicketState,
+        sessionId: String = "session-1",
+    ) = MatchTicket(
+        ticketId = ticketId,
+        userId = userId,
+        mmr = 1000L,
+        state = state,
+        version = 1L,
+        matchInfo = if (state == MatchTicketState.MATCHED) matchInfo(sessionId) else null,
+        serverId = 7L,
+        serverInstanceId = "instance-a",
+        createdAt = matchedAt,
+        updatedAt = matchedAt,
+    )
+
+    private fun seed(ticket: MatchTicket) {
+        sandbox.set("matching:ticket:${ticket.ticketId}", objectMapper.writeValueAsString(ticket))
+        sandbox.set("matching:active:${ticket.userId}", ticket.ticketId)
+        if (ticket.state == MatchTicketState.MATCHED) {
+            sandbox.zadd(MatchTicketRepository.MATCHED_KEY, ticket.ticketId, ticket.updatedAt.toEpochMilli().toDouble())
+        }
+    }
+
+    @Test
+    fun `MATCHED 전이는 티켓에 만료를 걸지 않는다`() = runTest {
+        val first = ticket("ticket-1", 1L, MatchTicketState.ALLOCATING)
+        val second = ticket("ticket-2", 2L, MatchTicketState.ALLOCATING)
+        seed(first)
+        seed(second)
+
+        val completed = repository.transitionPair(
+            first.copy(state = MatchTicketState.MATCHED, version = 2L, matchInfo = matchInfo()),
+            second.copy(state = MatchTicketState.MATCHED, version = 2L, matchInfo = matchInfo()),
+            MatchTicketState.ALLOCATING,
+        )
+
+        assertThat(completed).isTrue()
+        assertThat(sandbox.ttlMillis("matching:ticket:ticket-1"))
+            .`as`("30분을 넘는 세션의 티켓이 조용히 사라지면 안 된다")
+            .isNull()
+        assertThat(sandbox.ttlMillis("matching:ticket:ticket-2")).isNull()
+    }
+
+    @Test
+    fun `MATCHED 전이는 active 포인터를 유지한다`() = runTest {
+        val first = ticket("ticket-1", 1L, MatchTicketState.ALLOCATING)
+        val second = ticket("ticket-2", 2L, MatchTicketState.ALLOCATING)
+        seed(first)
+        seed(second)
+
+        repository.transitionPair(
+            first.copy(state = MatchTicketState.MATCHED, version = 2L, matchInfo = matchInfo()),
+            second.copy(state = MatchTicketState.MATCHED, version = 2L, matchInfo = matchInfo()),
+            MatchTicketState.ALLOCATING,
+        )
+
+        assertThat(sandbox.get("matching:active:1")).isEqualTo("ticket-1")
+        assertThat(sandbox.get("matching:active:2")).isEqualTo("ticket-2")
+    }
+
+    @Test
+    fun `MATCHED 전이는 matched 인덱스에 티켓을 등록한다`() = runTest {
+        val first = ticket("ticket-1", 1L, MatchTicketState.ALLOCATING)
+        val second = ticket("ticket-2", 2L, MatchTicketState.ALLOCATING)
+        seed(first)
+        seed(second)
+
+        repository.transitionPair(
+            first.copy(state = MatchTicketState.MATCHED, version = 2L, matchInfo = matchInfo()),
+            second.copy(state = MatchTicketState.MATCHED, version = 2L, matchInfo = matchInfo()),
+            MatchTicketState.ALLOCATING,
+        )
+
+        assertThat(sandbox.zmembers(MatchTicketRepository.MATCHED_KEY))
+            .containsExactlyInAnyOrder("ticket-1", "ticket-2")
+    }
+
+    @Test
+    fun `terminal 쌍 전이는 만료를 걸고 두 active 포인터를 모두 해제한다`() = runTest {
+        val first = ticket("ticket-1", 1L, MatchTicketState.MATCHED)
+        val second = ticket("ticket-2", 2L, MatchTicketState.MATCHED)
+        seed(first)
+        seed(second)
+
+        val completed = repository.transitionPair(
+            first.copy(state = MatchTicketState.FAILED, version = 2L, reason = "SESSION_LOST"),
+            second.copy(state = MatchTicketState.FAILED, version = 2L, reason = "SESSION_LOST"),
+            MatchTicketState.MATCHED,
+        )
+
+        assertThat(completed).isTrue()
+        assertThat(sandbox.ttlMillis("matching:ticket:ticket-1")).isEqualTo(Duration.ofMinutes(30).toMillis())
+        assertThat(sandbox.get("matching:active:1")).isNull()
+        assertThat(sandbox.get("matching:active:2")).isNull()
+        assertThat(sandbox.zmembers(MatchTicketRepository.MATCHED_KEY)).isEmpty()
+    }
+
+    @Test
+    fun `terminal 단일 전이는 자기 티켓을 가리킬 때만 active 포인터를 지운다`() = runTest {
+        val stale = ticket("ticket-old", 1L, MatchTicketState.MATCHED)
+        seed(stale)
+        // the user already re-queued, so the pointer names a newer ticket
+        sandbox.set("matching:active:1", "ticket-new")
+
+        repository.transition(
+            stale.copy(state = MatchTicketState.FAILED, version = 2L, reason = "SESSION_LOST"),
+            MatchTicketState.MATCHED,
+        )
+
+        assertThat(sandbox.get("matching:active:1"))
+            .`as`("이미 새 티켓을 들고 있으면 포인터를 건드리지 않는다")
+            .isEqualTo("ticket-new")
+    }
+
+    @Test
+    fun `terminal 단일 전이는 active 포인터를 해제하고 만료를 건다`() = runTest {
+        val matched = ticket("ticket-1", 1L, MatchTicketState.MATCHED)
+        seed(matched)
+
+        val released = repository.transition(
+            matched.copy(state = MatchTicketState.FAILED, version = 2L, reason = "SESSION_LOST"),
+            MatchTicketState.MATCHED,
+        )
+
+        assertThat(released?.state).isEqualTo(MatchTicketState.FAILED)
+        assertThat(sandbox.get("matching:active:1")).isNull()
+        assertThat(sandbox.ttlMillis("matching:ticket:ticket-1")).isEqualTo(Duration.ofMinutes(30).toMillis())
+        assertThat(sandbox.zmembers(MatchTicketRepository.MATCHED_KEY)).isEmpty()
+    }
+
+    @Test
+    fun `QUEUED로 복구되는 전이에는 만료가 남지 않는다`() = runTest {
+        val allocating = ticket("ticket-1", 1L, MatchTicketState.ALLOCATING)
+        seed(allocating)
+
+        repository.transition(
+            allocating.copy(state = MatchTicketState.QUEUED, version = 2L, reason = "ALLOCATION_LEASE_EXPIRED"),
+            MatchTicketState.ALLOCATING,
+        )
+
+        assertThat(sandbox.ttlMillis("matching:ticket:ticket-1")).isNull()
+        assertThat(sandbox.get("matching:active:1")).isEqualTo("ticket-1")
+        assertThat(sandbox.zmembers("matching:queue")).containsExactly("1")
+    }
+
+    @Test
+    fun `취소된 티켓은 active 포인터를 남기지 않는다`() = runTest {
+        val queued = ticket("ticket-1", 1L, MatchTicketState.QUEUED)
+        seed(queued)
+        sandbox.zadd("matching:queue", "1", matchedAt.toEpochMilli().toDouble())
+
+        val canceled = repository.cancel(1L, "ticket-1")
+
+        assertThat(canceled?.state).isEqualTo(MatchTicketState.CANCELED)
+        assertThat(sandbox.get("matching:active:1"))
+            .`as`("티켓 키만 만료되면 dangling 포인터가 남는다")
+            .isNull()
+        assertThat(sandbox.ttlMillis("matching:ticket:ticket-1")).isEqualTo(Duration.ofMinutes(30).toMillis())
+    }
+
+    @Test
+    fun `settledMatched는 유예 시간이 지난 MATCHED 티켓만 돌려준다`() = runTest {
+        val fresh = ticket("ticket-fresh", 1L, MatchTicketState.MATCHED)
+        val old = ticket("ticket-old", 2L, MatchTicketState.MATCHED, sessionId = "session-2")
+        sandbox.set("matching:ticket:ticket-fresh", objectMapper.writeValueAsString(fresh))
+        sandbox.set("matching:ticket:ticket-old", objectMapper.writeValueAsString(old))
+        sandbox.zadd(MatchTicketRepository.MATCHED_KEY, "ticket-fresh", matchedAt.toEpochMilli().toDouble())
+        sandbox.zadd(MatchTicketRepository.MATCHED_KEY, "ticket-old", matchedAt.minusSeconds(600).toEpochMilli().toDouble())
+
+        val settled = repository.settledMatched(matchedAt.minusSeconds(60), 10)
+
+        assertThat(settled.map { it.ticketId }).containsExactly("ticket-old")
+    }
+
+    @Test
+    fun `settledMatched는 사라진 티켓의 인덱스 항목을 정리한다`() = runTest {
+        sandbox.zadd(MatchTicketRepository.MATCHED_KEY, "ticket-gone", matchedAt.toEpochMilli().toDouble())
+
+        val settled = repository.settledMatched(matchedAt.plusSeconds(1), 10)
+
+        assertThat(settled).isEmpty()
+        assertThat(sandbox.zmembers(MatchTicketRepository.MATCHED_KEY)).isEmpty()
+    }
+}

--- a/src/test/kotlin/com/wordonline/matching/matching/repository/RedisScriptSandbox.kt
+++ b/src/test/kotlin/com/wordonline/matching/matching/repository/RedisScriptSandbox.kt
@@ -1,0 +1,209 @@
+package com.wordonline.matching.matching.repository
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import org.luaj.vm2.LuaTable
+import org.luaj.vm2.LuaValue
+import org.luaj.vm2.Varargs
+import org.luaj.vm2.lib.VarArgFunction
+import org.luaj.vm2.lib.jse.JsePlatform
+
+/**
+ * Runs the repository's Lua scripts on the JVM against an in-memory key space.
+ *
+ * The two bugs this change fixes - a terminal TTL applied to `MATCHED` tickets, and an
+ * active pointer that was never released - live entirely inside the scripts, where a
+ * mocked `ReactiveStringRedisTemplate` proves nothing: it would happily record the call
+ * and skip the branch under test. Executing the real script text is the only way to see
+ * whether the `PEXPIRE` fires.
+ *
+ * Deliberately not a redis server (nor Testcontainers): the suite has to run on a machine
+ * with no redis binary and no Docker. Only the commands the scripts actually use are
+ * implemented, and anything else fails loudly rather than silently doing nothing.
+ */
+class RedisScriptSandbox(private val objectMapper: ObjectMapper = ObjectMapper()) {
+
+    private val values = mutableMapOf<String, String>()
+    private val expiries = mutableMapOf<String, Long>()
+    private val sortedSets = mutableMapOf<String, MutableMap<String, Double>>()
+
+    /** Channel to payload, in publish order. */
+    val published = mutableListOf<Pair<String, String>>()
+
+    fun set(key: String, value: String) {
+        values[key] = value
+        expiries.remove(key)
+    }
+
+    fun get(key: String): String? = values[key]
+
+    fun exists(key: String): Boolean = values.containsKey(key)
+
+    /** Remaining TTL in milliseconds, or `null` when the key never expires. */
+    fun ttlMillis(key: String): Long? = expiries[key]
+
+    fun zadd(key: String, member: String, score: Double) {
+        sortedSets.getOrPut(key) { linkedMapOf() }[member] = score
+    }
+
+    fun zmembers(key: String): Set<String> = sortedSets[key].orEmpty().keys.toSet()
+
+    fun zrem(key: String, member: String) {
+        sortedSets[key]?.remove(member)
+    }
+
+    fun zscore(key: String, member: String): Double? = sortedSets[key]?.get(member)
+
+    fun eval(script: String, keys: List<String>, args: List<String>): Any? {
+        val globals = JsePlatform.standardGlobals()
+        globals.set("KEYS", luaArray(keys))
+        globals.set("ARGV", luaArray(args))
+        globals.set("redis", redisTable())
+        globals.set("cjson", cjsonTable())
+        return unwrap(globals.load(script, "script").call())
+    }
+
+    private fun luaArray(items: List<String>): LuaTable {
+        val table = LuaTable()
+        items.forEachIndexed { index, item -> table.set(index + 1, LuaValue.valueOf(item)) }
+        return table
+    }
+
+    private fun unwrap(value: LuaValue): Any? = when {
+        value.isnil() || value.isboolean() && !value.toboolean() -> null
+        value.isnumber() -> value.tolong()
+        else -> value.tojstring()
+    }
+
+    private fun redisTable(): LuaTable {
+        val table = LuaTable()
+        val call = object : VarArgFunction() {
+            override fun invoke(varargs: Varargs): Varargs = dispatch(varargs)
+        }
+        table.set("call", call)
+        table.set("pcall", call)
+        return table
+    }
+
+    private fun dispatch(varargs: Varargs): LuaValue {
+        val command = varargs.arg(1).tojstring().uppercase()
+        fun arg(index: Int) = varargs.arg(index).tojstring()
+
+        return when (command) {
+            "GET" -> values[arg(2)]?.let { LuaValue.valueOf(it) } ?: LuaValue.FALSE
+            "SET" -> {
+                val key = arg(2)
+                values[key] = arg(3)
+                // Redis clears any existing TTL on a plain SET; only an explicit PX re-arms it.
+                expiries.remove(key)
+                if (varargs.narg() >= 5 && arg(4).equals("PX", ignoreCase = true)) {
+                    expiries[key] = arg(5).toLong()
+                }
+                LuaValue.valueOf("OK")
+            }
+            "DEL" -> {
+                var removed = 0
+                for (index in 2..varargs.narg()) {
+                    if (values.remove(arg(index)) != null) removed++
+                    expiries.remove(arg(index))
+                }
+                LuaValue.valueOf(removed)
+            }
+            "PEXPIRE" -> {
+                val key = arg(2)
+                if (!values.containsKey(key)) return LuaValue.valueOf(0)
+                expiries[key] = arg(3).toLong()
+                LuaValue.valueOf(1)
+            }
+            "ZADD" -> {
+                val set = sortedSets.getOrPut(arg(2)) { linkedMapOf() }
+                var index = 3
+                while (index + 1 <= varargs.narg()) {
+                    set[arg(index + 1)] = arg(index).toDouble()
+                    index += 2
+                }
+                LuaValue.valueOf(1)
+            }
+            "ZREM" -> {
+                val set = sortedSets[arg(2)] ?: return LuaValue.valueOf(0)
+                var removed = 0
+                for (index in 3..varargs.narg()) {
+                    if (set.remove(arg(index)) != null) removed++
+                }
+                LuaValue.valueOf(removed)
+            }
+            "PUBLISH" -> {
+                published += arg(2) to arg(3)
+                LuaValue.valueOf(0)
+            }
+            else -> throw UnsupportedOperationException("redis command not emulated in tests: $command")
+        }
+    }
+
+    private fun cjsonTable(): LuaTable {
+        val table = LuaTable()
+        table.set("decode", object : VarArgFunction() {
+            override fun invoke(varargs: Varargs): Varargs = toLua(objectMapper.readTree(varargs.arg(1).tojstring()))
+        })
+        table.set("encode", object : VarArgFunction() {
+            override fun invoke(varargs: Varargs): Varargs =
+                LuaValue.valueOf(objectMapper.writeValueAsString(toJson(varargs.arg(1))))
+        })
+        return table
+    }
+
+    private fun toLua(node: JsonNode): LuaValue = when {
+        node.isNull -> LuaValue.NIL
+        node.isBoolean -> LuaValue.valueOf(node.booleanValue())
+        node.isNumber -> LuaValue.valueOf(node.doubleValue())
+        node.isTextual -> LuaValue.valueOf(node.textValue())
+        node.isArray -> LuaTable().also { table ->
+            node.forEachIndexed { index, child -> table.set(index + 1, toLua(child)) }
+        }
+        node.isObject -> LuaTable().also { table ->
+            node.fields().forEach { (name, child) -> table.set(name, toLua(child)) }
+        }
+        else -> LuaValue.NIL
+    }
+
+    private fun toJson(value: LuaValue): JsonNode = when {
+        value.isnil() -> objectMapper.nodeFactory.nullNode()
+        value.isboolean() -> objectMapper.nodeFactory.booleanNode(value.toboolean())
+        value.isnumber() -> numberNode(value.todouble())
+        value.isstring() -> objectMapper.nodeFactory.textNode(value.tojstring())
+        value.istable() -> tableToJson(value as LuaTable)
+        else -> objectMapper.nodeFactory.nullNode()
+    }
+
+    private fun numberNode(value: Double): JsonNode =
+        if (value == Math.floor(value) && !value.isInfinite()) {
+            objectMapper.nodeFactory.numberNode(value.toLong())
+        } else {
+            objectMapper.nodeFactory.numberNode(value)
+        }
+
+    private fun tableToJson(table: LuaTable): JsonNode {
+        val keys = generateSequence(LuaValue.NIL as LuaValue) { previous ->
+            table.next(previous).arg1().takeIf { !it.isnil() }
+        }.drop(1).toList()
+
+        if (keys.isNotEmpty() && keys.all { it.isnumber() }) {
+            val array: ArrayNode = objectMapper.nodeFactory.arrayNode()
+            keys.sortedBy { it.todouble() }.forEach { array.add(toJson(table.get(it))) }
+            return array
+        }
+        val obj: ObjectNode = objectMapper.nodeFactory.objectNode()
+        keys.forEach { key -> obj.set<JsonNode>(key.tojstring(), toJson(table.get(key))) }
+        return obj
+    }
+}
+
+private inline fun JsonNode.forEachIndexed(action: (Int, JsonNode) -> Unit) {
+    var index = 0
+    for (child in this) {
+        action(index, child)
+        index++
+    }
+}

--- a/src/test/kotlin/com/wordonline/matching/matching/repository/SandboxMatchTicketRepository.kt
+++ b/src/test/kotlin/com/wordonline/matching/matching/repository/SandboxMatchTicketRepository.kt
@@ -1,0 +1,97 @@
+package com.wordonline.matching.matching.repository
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.wordonline.matching.matching.config.MatchTicketProperties
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyVararg
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.Range
+import org.springframework.data.redis.connection.Limit
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+import org.springframework.data.redis.core.ReactiveValueOperations
+import org.springframework.data.redis.core.ReactiveZSetOperations
+import org.springframework.data.redis.core.script.RedisScript
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+/**
+ * A [MatchTicketRepository] whose redis calls land in [RedisScriptSandbox].
+ *
+ * Going through the real repository rather than evaluating the script constants directly is
+ * the point: the KEYS/ARGV ordering is the easiest thing to get wrong, and a test that
+ * restated that ordering itself would stay green while production broke.
+ */
+fun sandboxMatchTicketRepository(
+    sandbox: RedisScriptSandbox,
+    properties: MatchTicketProperties = MatchTicketProperties(),
+): MatchTicketRepository {
+    val objectMapper: ObjectMapper = Jackson2ObjectMapperBuilder.json().build()
+    val template: ReactiveStringRedisTemplate = mock()
+    val valueOps: ReactiveValueOperations<String, String> = mock()
+    val zSetOps: ReactiveZSetOperations<String, String> = mock()
+
+    whenever(template.opsForValue()).thenReturn(valueOps)
+    whenever(template.opsForZSet()).thenReturn(zSetOps)
+
+    whenever(template.execute(any<RedisScript<Any>>(), any<List<String>>(), any<List<Any>>()))
+        .thenAnswer { invocation ->
+            val script = invocation.getArgument<RedisScript<*>>(0)
+            val keys = invocation.getArgument<List<String>>(1)
+            val args = invocation.getArgument<List<*>>(2).map { it.toString() }
+            val result = sandbox.eval(script.scriptAsString, keys, args)
+            Flux.fromIterable(listOfNotNull(coerce(result, script.resultType)))
+        }
+
+    whenever(valueOps.get(any<String>())).thenAnswer { invocation ->
+        Mono.justOrEmpty(sandbox.get(invocation.getArgument<Any>(0).toString()))
+    }
+
+    whenever(zSetOps.rangeByScore(any<String>(), any<Range<Double>>(), any<Limit>()))
+        .thenAnswer { invocation ->
+            val key = invocation.getArgument<String>(0)
+            val range = invocation.getArgument<Range<Double>>(1)
+            val limit = invocation.getArgument<Limit>(2)
+            Flux.fromIterable(byScore(sandbox, key, range).let { if (limit.count > 0) it.take(limit.count) else it })
+        }
+
+    whenever(zSetOps.rangeByScore(any<String>(), any<Range<Double>>()))
+        .thenAnswer { invocation ->
+            Flux.fromIterable(byScore(sandbox, invocation.getArgument(0), invocation.getArgument(1)))
+        }
+
+    whenever(zSetOps.add(any<String>(), any<String>(), any<Double>())).thenAnswer { invocation ->
+        sandbox.zadd(invocation.getArgument(0), invocation.getArgument(1), invocation.getArgument(2))
+        Mono.just(true)
+    }
+
+    whenever(zSetOps.remove(any<String>(), anyVararg())).thenAnswer { invocation ->
+        val key = invocation.getArgument<String>(0)
+        val members = invocation.arguments.drop(1).flatMap { if (it is Array<*>) it.toList() else listOf(it) }
+        val removed = members.count { member ->
+            val existed = sandbox.zscore(key, member.toString()) != null
+            sandbox.zrem(key, member.toString())
+            existed
+        }
+        Mono.just(removed.toLong())
+    }
+
+    return MatchTicketRepository(template, objectMapper, properties)
+}
+
+private fun byScore(sandbox: RedisScriptSandbox, key: String, range: Range<Double>): List<String> {
+    val upper = range.upperBound.value.orElse(Double.POSITIVE_INFINITY)
+    val lower = range.lowerBound.value.orElse(Double.NEGATIVE_INFINITY)
+    return sandbox.zmembers(key)
+        .mapNotNull { member -> sandbox.zscore(key, member)?.let { member to it } }
+        .filter { (_, score) -> score in lower..upper }
+        .sortedBy { (_, score) -> score }
+        .map { (member, _) -> member }
+}
+
+private fun coerce(result: Any?, resultType: Class<*>?): Any? = when {
+    result == null -> null
+    resultType == Long::class.java || resultType == java.lang.Long::class.java -> (result as Number).toLong()
+    else -> result.toString()
+}

--- a/src/test/kotlin/com/wordonline/matching/matching/service/MatchedTicketReconcilerTest.kt
+++ b/src/test/kotlin/com/wordonline/matching/matching/service/MatchedTicketReconcilerTest.kt
@@ -1,0 +1,194 @@
+package com.wordonline.matching.matching.service
+
+import com.wordonline.matching.auth.dto.UserDetailResponseDto
+import com.wordonline.matching.auth.service.UserService
+import com.wordonline.matching.matching.config.MatchTicketProperties
+import com.wordonline.matching.matching.domain.MatchTicket
+import com.wordonline.matching.matching.domain.MatchTicketState
+import com.wordonline.matching.matching.dto.MatchedInfoDto
+import com.wordonline.matching.matching.repository.MatchTicketRepository
+import com.wordonline.matching.matching.repository.RedisScriptSandbox
+import com.wordonline.matching.matching.repository.sandboxMatchTicketRepository
+import com.wordonline.matching.server.config.GameServerProperties
+import com.wordonline.matching.server.entity.Server
+import com.wordonline.matching.server.entity.ServerState
+import com.wordonline.matching.server.entity.ServerType
+import com.wordonline.matching.server.exception.GameServerUnreachableException
+import com.wordonline.matching.server.service.ServerHealthRegistry
+import com.wordonline.matching.session.service.LegacyGameMatchService
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
+import reactor.core.publisher.Mono
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * The reconciler is the only thing watching a `MATCHED` ticket when both clients are gone,
+ * so its bias matters in both directions: it must eventually free a ticket whose host died,
+ * and it must not free one just because a probe was missed.
+ */
+class MatchedTicketReconcilerTest {
+
+    private val objectMapper = Jackson2ObjectMapperBuilder.json().build<com.fasterxml.jackson.databind.ObjectMapper>()
+    private val sandbox = RedisScriptSandbox()
+    private val properties = MatchTicketProperties(matchedScanGrace = Duration.ofSeconds(30))
+    private val repository = sandboxMatchTicketRepository(sandbox, properties)
+    private val legacyGameMatchService: LegacyGameMatchService = mock()
+    private val userService: UserService = mock()
+    private val serverProperties = GameServerProperties(failureThreshold = 3)
+    private val serverHealthRegistry = ServerHealthRegistry(serverProperties)
+
+    private val probe = SessionLivenessProbe(legacyGameMatchService, serverHealthRegistry)
+    private val recovery = LostSessionRecovery(repository, userService)
+    private val reconciler = MatchedTicketReconciler(repository, probe, recovery, serverHealthRegistry, properties)
+
+    private val host = "http://localhost:7777"
+    private val server = Server(
+        id = 7L,
+        protocol = "http",
+        domain = "localhost",
+        port = 7777,
+        state = ServerState.ACTIVE,
+        type = ServerType.GAME,
+        instanceId = "boot-1",
+    )
+
+    init {
+        whenever(userService.markOnline(any())).thenReturn(Mono.empty())
+        serverHealthRegistry.replaceServers(listOf(server))
+        serverHealthRegistry.recordProbe(7L, true)
+    }
+
+    private fun seedMatchedPair(sessionId: String = "session-1", matchedAt: Instant = Instant.now().minusSeconds(600)) {
+        val info = MatchedInfoDto(
+            message = "Successfully Matched",
+            server = host,
+            leftUser = UserDetailResponseDto(1L, "left", "left@team6515.com"),
+            rightUser = UserDetailResponseDto(2L, "right", "right@team6515.com"),
+            sessionId = sessionId,
+            webSocketUrl = "ws://localhost:7777/ws",
+        )
+        listOf("ticket-1" to 1L, "ticket-2" to 2L).forEach { (ticketId, userId) ->
+            val ticket = MatchTicket(
+                ticketId = ticketId,
+                userId = userId,
+                mmr = 1000L,
+                state = MatchTicketState.MATCHED,
+                version = 2L,
+                matchInfo = info,
+                serverId = 7L,
+                serverInstanceId = "boot-1",
+                createdAt = matchedAt,
+                updatedAt = matchedAt,
+            )
+            sandbox.set("matching:ticket:$ticketId", objectMapper.writeValueAsString(ticket))
+            sandbox.set("matching:active:$userId", ticketId)
+            sandbox.zadd(MatchTicketRepository.MATCHED_KEY, ticketId, matchedAt.toEpochMilli().toDouble())
+        }
+    }
+
+    @Test
+    fun `호스트가 세션 없음을 답하면 양쪽 티켓을 정리한다`() = runTest {
+        seedMatchedPair()
+        whenever(legacyGameMatchService.isSessionActive(host, "session-1")).thenReturn(false)
+
+        reconciler.reconcile()
+
+        assertThat(decoded("ticket-1").state).isEqualTo(MatchTicketState.FAILED)
+        assertThat(decoded("ticket-2").state).isEqualTo(MatchTicketState.FAILED)
+        assertThat(decoded("ticket-1").reason).isEqualTo("SESSION_LOST")
+        assertThat(sandbox.get("matching:active:1")).isNull()
+        assertThat(sandbox.get("matching:active:2")).isNull()
+    }
+
+    @Test
+    fun `한 번의 무응답으로는 세션을 끝내지 않는다`() = runTest {
+        seedMatchedPair()
+        whenever(legacyGameMatchService.isSessionActive(host, "session-1"))
+            .thenThrow(GameServerUnreachableException("unreachable"))
+        // one failed probe: below the registry's threshold, so the server is still healthy
+        serverHealthRegistry.recordProbe(7L, false)
+
+        reconciler.reconcile()
+
+        assertThat(decoded("ticket-1").state)
+            .`as`("일시적 무응답을 세션 종료로 오판하면 안 된다")
+            .isEqualTo(MatchTicketState.MATCHED)
+        assertThat(sandbox.get("matching:active:1")).isEqualTo("ticket-1")
+    }
+
+    @Test
+    fun `무응답이 임계치를 넘어 서버가 로테이션에서 빠지면 정리한다`() = runTest {
+        seedMatchedPair()
+        whenever(legacyGameMatchService.isSessionActive(host, "session-1"))
+            .thenThrow(GameServerUnreachableException("unreachable"))
+        repeat(serverProperties.failureThreshold) { serverHealthRegistry.recordProbe(7L, false) }
+
+        reconciler.reconcile()
+
+        assertThat(decoded("ticket-1").state).isEqualTo(MatchTicketState.FAILED)
+        assertThat(decoded("ticket-2").state).isEqualTo(MatchTicketState.FAILED)
+    }
+
+    @Test
+    fun `세션이 살아있으면 아무것도 건드리지 않는다`() = runTest {
+        seedMatchedPair()
+        whenever(legacyGameMatchService.isSessionActive(host, "session-1")).thenReturn(true)
+
+        reconciler.reconcile()
+
+        assertThat(decoded("ticket-1").state).isEqualTo(MatchTicketState.MATCHED)
+        assertThat(decoded("ticket-2").state).isEqualTo(MatchTicketState.MATCHED)
+        assertThat(sandbox.zmembers(MatchTicketRepository.MATCHED_KEY))
+            .containsExactlyInAnyOrder("ticket-1", "ticket-2")
+    }
+
+    @Test
+    fun `유예 시간 안에 있는 티켓은 감사하지 않는다`() = runTest {
+        seedMatchedPair(matchedAt = Instant.now())
+        whenever(legacyGameMatchService.isSessionActive(host, "session-1")).thenReturn(false)
+
+        reconciler.reconcile()
+
+        assertThat(decoded("ticket-1").state)
+            .`as`("게임 서버가 세션 등록을 마치기 전에 감사하면 살아있는 세션을 죽인다")
+            .isEqualTo(MatchTicketState.MATCHED)
+    }
+
+    @Test
+    fun `신고됐지만 판정 못 한 티켓은 유예 시간을 기다리지 않고 다시 확인한다`() = runTest {
+        seedMatchedPair(matchedAt = Instant.now())
+        sandbox.zadd(MatchTicketRepository.PENDING_VERIFICATION_KEY, "ticket-1", Instant.now().toEpochMilli().toDouble())
+        whenever(legacyGameMatchService.isSessionActive(host, "session-1")).thenReturn(false)
+
+        reconciler.reconcilePending()
+
+        assertThat(decoded("ticket-1").state).isEqualTo(MatchTicketState.FAILED)
+        assertThat(decoded("ticket-2").state).isEqualTo(MatchTicketState.FAILED)
+        assertThat(sandbox.zmembers(MatchTicketRepository.PENDING_VERIFICATION_KEY)).isEmpty()
+    }
+
+    @Test
+    fun `재확인에서도 호스트가 침묵하면 대기열에 남겨 다음 주기에 다시 본다`() = runTest {
+        seedMatchedPair()
+        sandbox.zadd(MatchTicketRepository.PENDING_VERIFICATION_KEY, "ticket-1", Instant.now().toEpochMilli().toDouble())
+        whenever(legacyGameMatchService.isSessionActive(host, "session-1"))
+            .thenThrow(GameServerUnreachableException("unreachable"))
+        serverHealthRegistry.recordProbe(7L, false)
+
+        reconciler.reconcilePending()
+
+        assertThat(decoded("ticket-1").state).isEqualTo(MatchTicketState.MATCHED)
+        assertThat(sandbox.zmembers(MatchTicketRepository.PENDING_VERIFICATION_KEY))
+            .`as`("확정 기준을 낮추지 않고 재확인만 반복한다")
+            .containsExactly("ticket-1")
+    }
+
+    private fun decoded(ticketId: String): MatchTicket =
+        objectMapper.readValue(sandbox.get("matching:ticket:$ticketId"), MatchTicket::class.java)
+}

--- a/src/test/kotlin/com/wordonline/matching/matching/service/SessionLostReportServiceTest.kt
+++ b/src/test/kotlin/com/wordonline/matching/matching/service/SessionLostReportServiceTest.kt
@@ -1,0 +1,253 @@
+package com.wordonline.matching.matching.service
+
+import com.wordonline.matching.auth.dto.UserDetailResponseDto
+import com.wordonline.matching.auth.service.UserService
+import com.wordonline.matching.global.service.LocalizationService
+import com.wordonline.matching.matching.domain.MatchTicket
+import com.wordonline.matching.matching.domain.MatchTicketState
+import com.wordonline.matching.matching.domain.SessionLostReport
+import com.wordonline.matching.matching.dto.MatchedInfoDto
+import com.wordonline.matching.matching.repository.MatchTicketRepository
+import com.wordonline.matching.matching.repository.RedisScriptSandbox
+import com.wordonline.matching.matching.repository.sandboxMatchTicketRepository
+import com.wordonline.matching.server.entity.Server
+import com.wordonline.matching.server.entity.ServerState
+import com.wordonline.matching.server.entity.ServerType
+import com.wordonline.matching.server.exception.GameServerUnreachableException
+import com.wordonline.matching.server.service.ServerHealthRegistry
+import com.wordonline.matching.session.service.LegacyGameMatchService
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
+import reactor.core.publisher.Mono
+import java.time.Instant
+
+/**
+ * The endpoint's contract: a client report only points the lobby at a session, and the
+ * lobby's own verification is the only thing that can end a ticket.
+ */
+class SessionLostReportServiceTest {
+
+    private val objectMapper = Jackson2ObjectMapperBuilder.json().build<com.fasterxml.jackson.databind.ObjectMapper>()
+    private val sandbox = RedisScriptSandbox()
+    private val repository = sandboxMatchTicketRepository(sandbox)
+    private val legacyGameMatchService: LegacyGameMatchService = mock()
+    private val userService: UserService = mock()
+    private val localizationService: LocalizationService = mock()
+    private val serverHealthRegistry = ServerHealthRegistry(com.wordonline.matching.server.config.GameServerProperties())
+
+    private val probe = SessionLivenessProbe(legacyGameMatchService, serverHealthRegistry)
+    private val recovery = LostSessionRecovery(repository, userService)
+    private val service = SessionLostReportService(repository, probe, recovery, localizationService)
+
+    private val matchedAt = Instant.parse("2026-08-10T00:00:00Z")
+    private val host = "http://localhost:7777"
+
+    init {
+        whenever(userService.markOnline(any())).thenReturn(Mono.empty())
+        whenever(localizationService.getMessage(any(), any())).thenAnswer { it.getArgument(1) }
+        serverHealthRegistry.replaceServers(
+            listOf(
+                Server(
+                    id = 7L,
+                    protocol = "http",
+                    domain = "localhost",
+                    port = 7777,
+                    state = ServerState.ACTIVE,
+                    type = ServerType.GAME,
+                    instanceId = "boot-1",
+                ),
+            ),
+        )
+    }
+
+    private fun matchInfo(sessionId: String) = MatchedInfoDto(
+        message = "Successfully Matched",
+        server = host,
+        leftUser = UserDetailResponseDto(1L, "left", "left@team6515.com"),
+        rightUser = UserDetailResponseDto(2L, "right", "right@team6515.com"),
+        sessionId = sessionId,
+        webSocketUrl = "ws://localhost:7777/ws",
+    )
+
+    private fun matchedTicket(
+        ticketId: String,
+        userId: Long,
+        sessionId: String = "session-1",
+        instanceId: String? = "boot-1",
+    ) = MatchTicket(
+        ticketId = ticketId,
+        userId = userId,
+        mmr = 1000L,
+        state = MatchTicketState.MATCHED,
+        version = 2L,
+        matchInfo = matchInfo(sessionId),
+        serverId = 7L,
+        serverInstanceId = instanceId,
+        createdAt = matchedAt,
+        updatedAt = matchedAt,
+    )
+
+    private fun seed(ticket: MatchTicket) {
+        sandbox.set("matching:ticket:${ticket.ticketId}", objectMapper.writeValueAsString(ticket))
+        sandbox.set("matching:active:${ticket.userId}", ticket.ticketId)
+        if (ticket.state == MatchTicketState.MATCHED) {
+            sandbox.zadd(MatchTicketRepository.MATCHED_KEY, ticket.ticketId, ticket.updatedAt.toEpochMilli().toDouble())
+        }
+    }
+
+    @Test
+    fun `세션이 살아있으면 신고해도 티켓을 끝내지 않는다`() = runTest {
+        seed(matchedTicket("ticket-1", 1L))
+        seed(matchedTicket("ticket-2", 2L))
+        whenever(legacyGameMatchService.isSessionActive(host, "session-1")).thenReturn(true)
+
+        val report = service.report(1L, "session-1")
+
+        assertThat(report).isInstanceOf(SessionLostReport.SessionAlive::class.java)
+        assertThat(repository.getActive(1L)?.state).isEqualTo(MatchTicketState.MATCHED)
+        assertThat(repository.getActive(2L)?.state).isEqualTo(MatchTicketState.MATCHED)
+        verify(userService, never()).markOnline(any())
+    }
+
+    @Test
+    fun `세션이 사라졌으면 양쪽 티켓을 FAILED로 정리한다`() = runTest {
+        seed(matchedTicket("ticket-1", 1L))
+        seed(matchedTicket("ticket-2", 2L))
+        whenever(legacyGameMatchService.isSessionActive(host, "session-1")).thenReturn(false)
+
+        val report = service.report(1L, "session-1")
+
+        assertThat(report).isInstanceOf(SessionLostReport.Released::class.java)
+        assertThat((report as SessionLostReport.Released).ticket.reason).isEqualTo("SESSION_LOST")
+        assertThat(sandbox.get("matching:active:1")).isNull()
+        assertThat(sandbox.get("matching:active:2")).isNull()
+        assertThat(decoded("ticket-2").state).isEqualTo(MatchTicketState.FAILED)
+        verify(userService).markOnline(1L)
+        verify(userService).markOnline(2L)
+    }
+
+    @Test
+    fun `상대가 이미 재큐했으면 상대의 새 티켓은 건드리지 않는다`() = runTest {
+        seed(matchedTicket("ticket-1", 1L))
+        val requeued = MatchTicket(
+            ticketId = "ticket-new",
+            userId = 2L,
+            mmr = 1000L,
+            state = MatchTicketState.QUEUED,
+            version = 1L,
+            createdAt = matchedAt,
+            updatedAt = matchedAt,
+        )
+        seed(requeued)
+        whenever(legacyGameMatchService.isSessionActive(host, "session-1")).thenReturn(false)
+
+        service.report(1L, "session-1")
+
+        assertThat(decoded("ticket-new").state)
+            .`as`("뒤늦은 신고가 상대의 새 매칭을 깨면 안 된다")
+            .isEqualTo(MatchTicketState.QUEUED)
+        assertThat(sandbox.get("matching:active:2")).isEqualTo("ticket-new")
+        assertThat(decoded("ticket-1").state).isEqualTo(MatchTicketState.FAILED)
+        verify(userService).markOnline(1L)
+        verify(userService, never()).markOnline(2L)
+    }
+
+    @Test
+    fun `호스트가 응답하지 않으면 티켓을 유지한 채 도달 불가로 답한다`() = runTest {
+        seed(matchedTicket("ticket-1", 1L))
+        seed(matchedTicket("ticket-2", 2L))
+        whenever(legacyGameMatchService.isSessionActive(host, "session-1"))
+            .thenThrow(GameServerUnreachableException("unreachable"))
+
+        val error = runCatching { service.report(1L, "session-1") }.exceptionOrNull()
+
+        assertThat(error).isInstanceOf(GameServerUnreachableException::class.java)
+        assertThat(decoded("ticket-1").state)
+            .`as`("일시적 통신 실패로 살아있는 세션을 끝내면 안 된다")
+            .isEqualTo(MatchTicketState.MATCHED)
+        assertThat(decoded("ticket-2").state).isEqualTo(MatchTicketState.MATCHED)
+        assertThat(sandbox.zmembers(MatchTicketRepository.PENDING_VERIFICATION_KEY))
+            .`as`("판정을 미룬 티켓은 다음 전체 스캔까지 방치되면 안 된다")
+            .containsExactly("ticket-1")
+    }
+
+    @Test
+    fun `세션이 살아있다고 확인되면 재확인 대기열에서 뺀다`() = runTest {
+        seed(matchedTicket("ticket-1", 1L))
+        sandbox.zadd(MatchTicketRepository.PENDING_VERIFICATION_KEY, "ticket-1", matchedAt.toEpochMilli().toDouble())
+        whenever(legacyGameMatchService.isSessionActive(host, "session-1")).thenReturn(true)
+
+        service.report(1L, "session-1")
+
+        assertThat(sandbox.zmembers(MatchTicketRepository.PENDING_VERIFICATION_KEY)).isEmpty()
+    }
+
+    @Test
+    fun `부팅 세대값이 다르면 호스트에 묻지 않고 세션 소실로 판정한다`() = runTest {
+        seed(matchedTicket("ticket-1", 1L, instanceId = "boot-0"))
+        seed(matchedTicket("ticket-2", 2L, instanceId = "boot-0"))
+
+        val report = service.report(1L, "session-1")
+
+        assertThat(report).isInstanceOf(SessionLostReport.Released::class.java)
+        verify(legacyGameMatchService, never()).isSessionActive(any(), any())
+    }
+
+    @Test
+    fun `세대값이 보고되지 않았으면 재시작으로 보지 않는다`() = runTest {
+        seed(matchedTicket("ticket-1", 1L, instanceId = null))
+        whenever(legacyGameMatchService.isSessionActive(host, "session-1")).thenReturn(true)
+
+        val report = service.report(1L, "session-1")
+
+        assertThat(report)
+            .`as`("구버전 게임 서버의 NULL을 재시작 증거로 쓰면 안 된다")
+            .isInstanceOf(SessionLostReport.SessionAlive::class.java)
+    }
+
+    @Test
+    fun `활성 티켓이 없으면 알 수 없는 세션이다`() = runTest {
+        val report = service.report(1L, "session-1")
+
+        assertThat(report).isEqualTo(SessionLostReport.UnknownSession)
+    }
+
+    @Test
+    fun `다른 세션을 신고하면 알 수 없는 세션이다`() = runTest {
+        seed(matchedTicket("ticket-1", 1L, sessionId = "session-1"))
+
+        val report = service.report(1L, "session-9")
+
+        assertThat(report).isEqualTo(SessionLostReport.UnknownSession)
+    }
+
+    @Test
+    fun `MATCHED가 아닌 티켓은 그대로 스냅샷을 돌려준다`() = runTest {
+        val queued = MatchTicket(
+            ticketId = "ticket-1",
+            userId = 1L,
+            mmr = 1000L,
+            state = MatchTicketState.QUEUED,
+            version = 1L,
+            matchInfo = matchInfo("session-1"),
+            createdAt = matchedAt,
+            updatedAt = matchedAt,
+        )
+        seed(queued)
+
+        val report = service.report(1L, "session-1")
+
+        assertThat(report).isInstanceOf(SessionLostReport.NothingToRelease::class.java)
+        assertThat((report as SessionLostReport.NothingToRelease).ticket.state).isEqualTo(MatchTicketState.QUEUED)
+    }
+
+    private fun decoded(ticketId: String): MatchTicket =
+        objectMapper.readValue(sandbox.get("matching:ticket:$ticketId"), MatchTicket::class.java)
+}

--- a/src/test/kotlin/com/wordonline/matching/session/service/LegacyGameMatchServiceTest.kt
+++ b/src/test/kotlin/com/wordonline/matching/session/service/LegacyGameMatchServiceTest.kt
@@ -52,7 +52,7 @@ class LegacyGameMatchServiceTest {
     private fun readyResponse(ready: Boolean): ClientResponse =
         ClientResponse.create(HttpStatus.OK)
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .body("""{"attemptId":"attempt-1","sessionId":"session-1","ready":$ready,"serverUrl":"http://internal:9090","webSocketUrl":"wss://game.example/ws"}""")
+            .body("""{"attemptId":"attempt-1","sessionId":"session-1","ready":$ready,"serverUrl":"http://internal:9090","webSocketUrl":"wss://game.example/ws","instanceId":"boot-1"}""")
             .build()
 
     private fun server(id: Long, domain: String) = Server(
@@ -83,11 +83,40 @@ class LegacyGameMatchServiceTest {
             readyResponse(request.url().host == "beta")
         }.createSession(sessionDto, "attempt-1")
 
-        assertThat(matched.server)
+        assertThat(matched.matchInfo.server)
             .`as`("첫 후보가 아니라 실제로 수락한 서버의 URL이어야 한다")
             .isEqualTo("http://internal:9090")
-        assertThat(matched.webSocketUrl).isEqualTo("wss://game.example/ws")
+        assertThat(matched.matchInfo.webSocketUrl).isEqualTo("wss://game.example/ws")
         assertThat(sentRequests.map { it.url().host }).containsExactly("alpha", "beta")
+    }
+
+    @Test
+    fun `수락한 서버의 id와 부팅 세대값을 배치 결과에 담는다`() = runTest {
+        stubUsers()
+        whenever(gameServerManagementService.getAvailableServers())
+            .thenReturn(listOf(server(1L, "alpha"), server(2L, "beta")))
+
+        val placement = service { request -> readyResponse(request.url().host == "beta") }
+            .createSession(sessionDto, "attempt-1")
+
+        assertThat(placement.serverId)
+            .`as`("호스트 생존 판정은 실제로 수락한 서버 행을 봐야 한다")
+            .isEqualTo(2L)
+        assertThat(placement.serverInstanceId).isEqualTo("boot-1")
+    }
+
+    @Test
+    fun `부팅 세대값을 보내지 않는 구버전 게임 서버도 배치에 성공한다`() = runTest {
+        stubUsers()
+        whenever(gameServerManagementService.getAvailableServers()).thenReturn(listOf(server(1L, "alpha")))
+        val withoutInstanceId = ClientResponse.create(HttpStatus.OK)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body("""{"attemptId":"attempt-1","sessionId":"session-1","ready":true,"serverUrl":"http://alpha:9090","webSocketUrl":"wss://alpha/ws"}""")
+            .build()
+
+        val placement = service { withoutInstanceId }.createSession(sessionDto, "attempt-1")
+
+        assertThat(placement.serverInstanceId).isNull()
     }
 
     @Test
@@ -106,8 +135,8 @@ class LegacyGameMatchServiceTest {
         )
 
         val matched = service.createSession(sessionDto, "attempt-1")
-        assertThat(matched.server).isEqualTo("http://internal:9090")
-        assertThat(matched.webSocketUrl).isEqualTo("wss://game.example/ws")
+        assertThat(matched.matchInfo.server).isEqualTo("http://internal:9090")
+        assertThat(matched.matchInfo.webSocketUrl).isEqualTo("wss://game.example/ws")
     }
 
     @Test

--- a/src/test/resources/contract/session-ready-response.json
+++ b/src/test/resources/contract/session-ready-response.json
@@ -3,5 +3,6 @@
   "sessionId": "session-1",
   "ready": true,
   "serverUrl": "http://localhost:7777",
-  "webSocketUrl": "http://localhost:7777/ws"
+  "webSocketUrl": "http://localhost:7777/ws",
+  "instanceId": "00000000-0000-0000-0000-000000000001"
 }


### PR DESCRIPTION
Closes #96

## 문제

게임 서버는 세션을 `SessionService`의 인메모리 맵에만 들고 있고 재시작을 로비에 알리지 않는다.
`GameMatchService.tryMatching`은 `ALLOCATING`(lease 만료)과 `QUEUED`(큐 타임아웃)만 복구하므로
`MATCHED` 티켓을 감시하는 주체가 없었다. 그 결과 `ENQUEUE_SCRIPT`가 계속 죽은 티켓을 돌려주면서
재큐가 막히고 `user_status`가 `OnPlaying`으로 남았다.

## 함께 고친 부수 버그

- `TRANSITION_PAIR_SCRIPT`가 `SET ... 'PX'`로 terminal TTL을 무조건 걸어서 `MATCHED` 티켓까지
  30분 뒤 조용히 사라졌다. 이제 `CANCELED`/`EXPIRED`/`FAILED`일 때만 `PEXPIRE`한다.
  `TRANSITION_SCRIPT`도 같은 문제가 있어 함께 고쳤다.
- `matching:active:<userId>`에 삭제도 TTL도 없어 dangling 포인터가 남았다. terminal 전이 시
  **그 티켓을 가리키고 있을 때만** compare-and-delete 한다. 이미 재큐한 사용자의 새 티켓은 지키기 위해서다.

## 호스트 재시작 판별

게임 서버가 부팅마다 새로 만드는 `instanceId`를 `SessionReadyResponse`(6번째 필드)와
`public.servers.instance_id`에 함께 쓴다. 로비는 매칭 시점의 값과 수락한 서버의 `servers.id`를
티켓에 보관했다가 현재 값과 비교한다. 값이 다르면 호스트 프로세스가 교체된 것이므로 세션 소실 확정.
어느 한쪽이라도 `NULL`이면 "보고되지 않음"이며 재시작 증거로 쓰지 않고 세션 조회로 넘어간다.

## 추가 엔드포인트

`POST /api/match/sessions/{sessionId}/report-lost`

클라이언트가 legacy 매칭 흐름을 쓰므로 `ticketId`는 모르고 `sessionId`만 안다. 그래서 session 기준 경로다.
ticket은 `@UserId`로 찾고 `matchInfo.sessionId`가 경로와 일치하는지 검증한다.

| Status | 조건 | Body |
|---|---|---|
| `200` | 세션 소실 확정 → `FAILED(SESSION_LOST)` + `markOnline`. 또는 애초에 `MATCHED`가 아니었음 | MatchTicket |
| `409` | 세션이 살아있음. 티켓 유지 | MatchTicket |
| `404` | 활성 ticket 없음 또는 다른 세션 | - |
| `503` | 호스트 무응답. 종료 확정이 아니므로 티켓 유지 (`GameServerUnreachableException` 정책 재사용) | 메시지 |

**신고만으로는 살아있는 세션을 끝낼 수 없다.** 판정은 전적으로 서버 검증이 한다.

소실이 확정되면 상대방 티켓도 정리한다. 단 `matching:active:<상대userId>`가 가리키는 티켓의
`matchInfo.sessionId`가 같은 세션일 때만이다. 양쪽이 대상이면 `transitionPair`, 한쪽뿐이면 단일 `transition`.

## MATCHED reconciler

아무도 신고하지 않는 경우(양쪽 이탈)의 안전망. `matching:matched` ZSET 인덱스를 신설해
상태 전이와 원자적으로 유지하고, 주기적으로 훑으며 엔드포인트와 **동일한** 기준을 적용한다.
1회 무응답으로 확정하지 않고 `ServerHealthRegistry`의 hysteresis(`gameserver.failure-threshold`
연속 실패)를 재사용한다.

`503`을 받은 티켓은 `matching:matched:pending`에 올려 훨씬 짧은 주기로 재확인한다.
클라이언트가 `MATCHED` 스냅샷마다 게임 씬으로 재진입하기 때문에, 판정을 미루면 다음 전체 스캔까지
로비↔게임 씬을 왕복한다(WordOnlineClient#481). 확정 기준을 낮추지 않고 **재확인 시점만** 앞당긴다.

모든 값은 `MatchTicketProperties`로 뺐다.

| 설정 | 기본값 |
|---|---|
| `matching.ticket.matched-scan-interval` | `30s` (세션 수명보다 크게 잡으면 사실상 비활성화) |
| `matching.ticket.pending-scan-interval` | `3s` |
| `matching.ticket.matched-scan-grace` | `30s` |
| `matching.ticket.matched-scan-batch-size` | `100` |

## 테스트

`./gradlew test` — 86 tests, 0 failures, 0 skipped.

Lua 스크립트는 `RedisScriptSandbox`(luaj + 인메모리 키 공간)로 **실제 스크립트 본문을 실행**해
검증한다. TTL과 active 포인터 버그는 전부 스크립트 안에 있어서 mock으로는 분기 자체가 실행되지 않는다.
redis 바이너리나 Docker 없이 도는 것도 의도적이다. 테스트는 스크립트 상수를 직접 부르지 않고
실제 `MatchTicketRepository`를 거치므로 KEYS/ARGV 순서까지 함께 검증된다.
버그를 되살려 두 테스트가 실제로 실패하는 것도 확인했다.

- 엔드포인트 세 판정(200/409/503) + 404 + `MATCHED` 아님
- 살아있는 세션은 신고를 받아도 종료되지 않음
- 1회 무응답으로는 확정하지 않고, 임계치를 넘어야 확정
- 상대방 정리 O / 상대가 새 티켓을 들고 있으면 X
- `MATCHED`에 TTL이 붙지 않고, terminal 전이에서 `matching:active:<userId>`가 해제됨
- 세대값 불일치는 호스트에 묻지 않고 확정, `NULL`은 재시작으로 보지 않음

## 연동 필요

- **게임 서버**: `SessionReadyResponse.instanceId` 추가 및 `servers.instance_id` 기록
  (Apptive-Game-Team/WordOnlineServer#371). 공유 계약 픽스처
  `src/test/resources/contract/session-ready-response.json`을 양쪽 동일하게 갱신했다(byte-identical 확인).
- **DB**: `V041_20260810__add_server_instance_id.sql` (WordOnlineDatabase). 컬럼이 없어도
  `instance_id`는 `NULL`로 읽히고 세션 조회 폴백으로 동작한다.
- **클라이언트**: Apptive-Game-Team/WordOnlineClient#480, #481

## 남은 리스크

- 세션을 호스팅한 `servers` 행을 찾을 수 없으면(운영자가 행을 삭제한 경우 등) hysteresis 근거가 없어
  reconciler가 확정하지 않는다. `MATCHED`에 더 이상 TTL이 없으므로 이 경우 티켓이 남는다.
  대신 티켓에 `serverId`를 기록해 URL 매칭 실패로 인한 오식별은 없앴다.
- 테스트용 `org.luaj:luaj-jse` 의존성이 추가됐다(`testImplementation`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)