### PR TITLE
feature: expose magic cast type in data API

### DIFF
--- a/src/main/java/com/wordonline/matching/magic/domain/Magic.java
+++ b/src/main/java/com/wordonline/matching/magic/domain/Magic.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 @Getter
@@ -15,4 +16,7 @@ public class Magic {
     @Id
     private Long id;
     private String name;
+
+    @Column("cast_type")
+    private String castType;
 }

--- a/src/main/java/com/wordonline/matching/magic/dto/MagicDto.java
+++ b/src/main/java/com/wordonline/matching/magic/dto/MagicDto.java
@@ -5,6 +5,7 @@ import java.util.List;
 public record MagicDto(
         Long id,
         String name,
+        String castType,
         List<String> cards
 ) {
 }

--- a/src/main/java/com/wordonline/matching/magic/service/MagicDataService.java
+++ b/src/main/java/com/wordonline/matching/magic/service/MagicDataService.java
@@ -102,7 +102,7 @@ public class MagicDataService {
                                                     })
                                                     .filter(Objects::nonNull)
                                                     .collect(Collectors.toList());
-                                            return new MagicDto(magicId, magic.getName(), cards);
+                                            return new MagicDto(magicId, magic.getName(), magic.getCastType(), cards);
                                         })
                                         .collect(Collectors.toList());
 

--- a/src/test/java/com/wordonline/matching/data/controller/DataControllerTest.java
+++ b/src/test/java/com/wordonline/matching/data/controller/DataControllerTest.java
@@ -35,7 +35,7 @@ class DataControllerTest {
     @Test
     @DisplayName("마법_전체_조회_버전없음_성공")
     void getMagics_WithoutVersion_ReturnsAllMagics() {
-        MagicDto magicDto = new MagicDto(1L, "fireball", List.of("Fire", "Fire", "Shoot"));
+        MagicDto magicDto = new MagicDto(1L, "fireball", "shoot", List.of("Fire", "Fire", "Shoot"));
         MagicsResponse mockResponse = new MagicsResponse("2024-01-01T00:00:00", List.of(magicDto), true);
 
         when(magicDataService.getMagics(isNull())).thenReturn(Mono.just(mockResponse));
@@ -52,6 +52,7 @@ class DataControllerTest {
                     assert response.magics().size() == 1;
                     assert response.magics().get(0).id().equals(1L);
                     assert response.magics().get(0).name().equals("fireball");
+                    assert response.magics().get(0).castType().equals("shoot");
                     assert response.magics().get(0).cards().equals(List.of("Fire", "Fire", "Shoot"));
                     assert response.requiresRefresh();
                 });

--- a/src/test/java/com/wordonline/matching/magic/service/MagicDataServiceTest.java
+++ b/src/test/java/com/wordonline/matching/magic/service/MagicDataServiceTest.java
@@ -60,8 +60,8 @@ class MagicDataServiceTest {
                 .thenReturn(Flux.just(fullFireballCardOne, fullFireballCardTwo, fullIceWallCard));
         when(magicRepository.findAllById(List.of(10L, 20L)))
                 .thenReturn(Flux.just(
-                        new Magic(10L, "fireball"),
-                        new Magic(20L, "ice_wall")
+                        new Magic(10L, "fireball", "shoot"),
+                        new Magic(20L, "ice_wall", "build")
                 ));
         when(cardRepository.findAllById(List.of(100L, 101L, 200L)))
                 .thenReturn(Flux.just(fireCard, shootCard, waterCard));
@@ -85,7 +85,7 @@ class MagicDataServiceTest {
         when(magicCardRepository.findAll())
                 .thenReturn(Flux.just(magicCard));
         when(magicRepository.findAllById(List.of(10L)))
-                .thenReturn(Flux.just(new Magic(10L, "fireball")));
+                .thenReturn(Flux.just(new Magic(10L, "fireball", "shoot")));
         when(cardRepository.findAllById(List.of(100L)))
                 .thenReturn(Flux.just(fireCard));
 
@@ -127,10 +127,12 @@ class MagicDataServiceTest {
         assert response.magics().stream().anyMatch(magic ->
                 magic.id().equals(10L)
                         && magic.name().equals("fireball")
+                        && magic.castType().equals("shoot")
                         && magic.cards().equals(List.of("Fire", "Shoot")));
         assert response.magics().stream().anyMatch(magic ->
                 magic.id().equals(20L)
                         && magic.name().equals("ice_wall")
+                        && magic.castType().equals("build")
                         && magic.cards().equals(List.of("Water")));
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> This feature works only after all three pull requests below are merged and deployed together.

## Required pull requests
- Database: [WordOnlineDatabase #44](https://github.com/Apptive-Game-Team/WordOnlineDatabase/pull/44)
- Matching: [WordOnlineMatching #102](https://github.com/Apptive-Game-Team/WordOnlineMatching/pull/102)
- Client: [WordOnlineClient #486](https://github.com/Apptive-Game-Team/WordOnlineClient/pull/486)

## Summary
- Map `magics.cast_type` on the Magic entity.
- Include `castType` in `MagicDto` and `GET /api/data/magics`.
- Update API and service tests.

## Validation
- Full Gradle test suite passed.

Closes #101