### PR TITLE
fix: 매칭 SSE 스트림이 프록시를 통과하도록 keep-alive와 버퍼링 해제 추가 (#103)

### DIFF
--- a/src/main/kotlin/com/wordonline/matching/matching/config/MatchEventStreamProperties.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/config/MatchEventStreamProperties.kt
@@ -1,0 +1,15 @@
+package com.wordonline.matching.matching.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
+
+@ConfigurationProperties("matching.events")
+data class MatchEventStreamProperties(
+    /**
+     * How often `/api/match/events` emits a keep-alive comment. Ticket updates are rare, so
+     * without traffic a proxy or load balancer closes the idle stream and the client stops
+     * hearing about its own match. Keep it below the shortest idle timeout in front of this
+     * service.
+     */
+    val heartbeatInterval: Duration = Duration.ofSeconds(15),
+)

--- a/src/main/kotlin/com/wordonline/matching/matching/controller/MatchingController.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/controller/MatchingController.kt
@@ -1,6 +1,7 @@
 package com.wordonline.matching.matching.controller
 
 import com.wordonline.matching.auth.service.UserId
+import com.wordonline.matching.matching.config.MatchEventStreamProperties
 import com.wordonline.matching.matching.dto.MatchedInfoDto
 import com.wordonline.matching.matching.dto.QueueLengthResponseDto
 import com.wordonline.matching.matching.dto.SimpleMessageDto
@@ -9,12 +10,16 @@ import com.wordonline.matching.matching.service.SessionLostReportService
 import com.wordonline.matching.matching.domain.CancelMatchResponse
 import com.wordonline.matching.matching.domain.MatchTicket
 import com.wordonline.matching.matching.domain.SessionLostReport
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.codec.ServerSentEvent
 import org.springframework.http.ResponseEntity
+import org.springframework.http.server.reactive.ServerHttpResponse
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -25,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController
 class MatchingController(
     private val gameMatchService: GameMatchService,
     private val sessionLostReportService: SessionLostReportService,
+    private val matchEventStreamProperties: MatchEventStreamProperties,
 ) {
     @GetMapping("/api/match/practice/me")
     suspend fun matchPractice(@UserId userId: Long?): MatchedInfoDto {
@@ -85,12 +91,41 @@ class MatchingController(
         SessionLostReport.UnknownSession -> ResponseEntity.notFound().build()
     }
 
+    /**
+     * Pushes ticket updates to the client.
+     *
+     * The stream is silent between updates, which is what breaks it in production: a
+     * buffering proxy holds frames until its buffer fills, and an idle-timeout proxy drops
+     * the connection outright. Both leave the client waiting on a match it has already been
+     * given. The keep-alive comments and the no-buffering headers below exist for that, not
+     * for the protocol.
+     */
     @GetMapping("/api/match/events", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
-    fun events(@UserId userId: Long?): Flow<ServerSentEvent<MatchTicket>> = gameMatchService.events(userId!!).map { ticket ->
-        ServerSentEvent.builder(ticket)
-            .id(ticket.version.toString())
-            .event("match-ticket-updated")
-            .build()
+    fun events(@UserId userId: Long?, response: ServerHttpResponse): Flow<ServerSentEvent<MatchTicket>> {
+        // nginx buffers a proxied response by default; `no-transform` stops a proxy from
+        // gzipping the stream, which would buffer it just as effectively.
+        response.headers.set("X-Accel-Buffering", "no")
+        response.headers.cacheControl = "no-cache, no-transform"
+
+        val ticketUpdates = gameMatchService.events(userId!!).map { ticket ->
+            ServerSentEvent.builder(ticket)
+                .id(ticket.version.toString())
+                .event("match-ticket-updated")
+                .build()
+        }
+        return merge(heartbeats(), ticketUpdates)
+    }
+
+    /**
+     * Emits once immediately so the response headers and a first byte reach the client before
+     * any ticket update, then keeps the stream warm.
+     */
+    private fun heartbeats(): Flow<ServerSentEvent<MatchTicket>> = flow {
+        val heartbeat = ServerSentEvent.builder<MatchTicket>().comment("keep-alive").build()
+        while (true) {
+            emit(heartbeat)
+            delay(matchEventStreamProperties.heartbeatInterval.toMillis())
+        }
     }
 
     @GetMapping("/api/match/length")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -73,6 +73,11 @@ matching:
     # A ticket is audited only once it has been MATCHED for at least this long.
     matched-scan-grace: ${MATCHING_MATCHED_SCAN_GRACE:30s}
     matched-scan-batch-size: ${MATCHING_MATCHED_SCAN_BATCH_SIZE:100}
+  # Bound to MatchEventStreamProperties.
+  events:
+    # Keep-alive cadence for the /api/match/events SSE stream. Must stay below the shortest
+    # idle timeout of any proxy in front of this service.
+    heartbeat-interval: ${MATCHING_EVENTS_HEARTBEAT_INTERVAL:15s}
 
 # Bound to GameServerProperties.
 gameserver:

--- a/src/test/kotlin/com/wordonline/matching/matching/controller/MatchEventStreamTest.kt
+++ b/src/test/kotlin/com/wordonline/matching/matching/controller/MatchEventStreamTest.kt
@@ -1,0 +1,88 @@
+package com.wordonline.matching.matching.controller
+
+import com.wordonline.matching.matching.config.MatchEventStreamProperties
+import com.wordonline.matching.matching.domain.MatchTicket
+import com.wordonline.matching.matching.domain.MatchTicketState
+import com.wordonline.matching.matching.service.GameMatchService
+import com.wordonline.matching.matching.service.SessionLostReportService
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.mock.http.server.reactive.MockServerHttpResponse
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * A silent SSE stream is indistinguishable from a working one until a match is missed, so the
+ * keep-alive and the anti-buffering headers are the parts worth pinning down.
+ */
+class MatchEventStreamTest {
+
+    private val gameMatchService: GameMatchService = mock()
+    private val sessionLostReportService: SessionLostReportService = mock()
+
+    private fun controller(heartbeatInterval: Duration = Duration.ofMillis(10)) = MatchingController(
+        gameMatchService,
+        sessionLostReportService,
+        MatchEventStreamProperties(heartbeatInterval = heartbeatInterval),
+    )
+
+    @Test
+    fun `프록시 버퍼링을 끄는 헤더를 응답에 붙인다`() = runTest {
+        whenever(gameMatchService.events(USER_ID)).thenReturn(emptyFlow())
+        val response = MockServerHttpResponse()
+
+        controller().events(USER_ID, response)
+
+        assertThat(response.headers.getFirst("X-Accel-Buffering")).isEqualTo("no")
+        assertThat(response.headers.cacheControl).isEqualTo("no-cache, no-transform")
+    }
+
+    /** The first frame has to leave before any ticket update, or the client waits on a silent socket. */
+    @Test
+    fun `구독 즉시 keep-alive를 보내고 주기적으로 반복한다`() = runTest {
+        whenever(gameMatchService.events(USER_ID)).thenReturn(emptyFlow())
+
+        val events = controller().events(USER_ID, MockServerHttpResponse()).take(2).toList()
+
+        assertThat(events).allSatisfy {
+            assertThat(it.comment()).isEqualTo("keep-alive")
+            assertThat(it.data() as MatchTicket?).isNull()
+        }
+    }
+
+    @Test
+    fun `keep-alive와 함께 티켓 갱신도 그대로 흘려보낸다`() = runTest {
+        whenever(gameMatchService.events(USER_ID)).thenReturn(flowOf(ticket))
+
+        val events = controller(heartbeatInterval = Duration.ofMinutes(1))
+            .events(USER_ID, MockServerHttpResponse())
+            .take(2)
+            .toList()
+
+        val update = events.single { it.data() != null }
+        assertThat(update.data() as MatchTicket?).isEqualTo(ticket)
+        assertThat(update.event()).isEqualTo("match-ticket-updated")
+        assertThat(update.id()).isEqualTo("7")
+    }
+
+    private companion object {
+        const val USER_ID = 42L
+
+        val ticket = MatchTicket(
+            ticketId = "ticket-1",
+            userId = USER_ID,
+            mmr = 1000,
+            state = MatchTicketState.QUEUED,
+            version = 7,
+            createdAt = Instant.parse("2026-08-14T00:00:00Z"),
+            updatedAt = Instant.parse("2026-08-14T00:00:00Z"),
+        )
+    }
+}


### PR DESCRIPTION
Closes #103

## 문제

배포 환경에서 매칭이 잡혀도 클라이언트가 게임 씬으로 넘어가지 않았다. Leave 를 누르거나 브라우저 포커스를 잃었다 되찾아야 입장됐는데, 두 동작 모두 클라이언트가 티켓 스냅샷을 다시 조회하는 경로다. 즉 `/api/match/events` 가 MATCHED 이벤트를 전달하지 못하고 수동 폴링만 상태를 따라잡고 있었다.

서버 발행 경로(`PUBLISH matching:event:{userId}` → `listenToChannel`)는 정상이다. 스트림이 티켓 갱신 사이에 완전히 조용하다는 점이 원인이다. 버퍼링 프록시는 버퍼가 찰 때까지 프레임을 붙잡고, idle timeout 이 있는 프록시는 조용한 연결을 끊는다.

## 변경

- `GET /api/match/events` 응답에 `X-Accel-Buffering: no` 와 `Cache-Control: no-cache, no-transform` 설정. 후자는 프록시가 gzip 변환으로 다시 버퍼링하는 것을 막는다.
- keep-alive comment 프레임을 주기적으로 흘린다. 구독 즉시 1회 emit 하므로 응답 헤더와 첫 바이트가 매칭 이전에 클라이언트에 도달한다.
- `MatchEventStreamProperties` 신규. `matching.events.heartbeat-interval` (기본 15s, `MATCHING_EVENTS_HEARTBEAT_INTERVAL` 로 오버라이드).

## 클라이언트 영향

없음. keep-alive 는 SSE comment 라 WebGL `MatchEventStream.jslib` 와 에디터용 `SseDownloadHandler` 양쪽 모두 `data:` 라인만 읽어 무시한다.

## 영향 엔드포인트

- `GET /api/match/events`

## 테스트

`MatchEventStreamTest` 추가: 버퍼링 해제 헤더, 즉시 발행 + 반복되는 keep-alive, 티켓 갱신 통과. `./gradlew test` 전체 통과 (113 tests, 0 failures).

## 후속 (이 PR 범위 밖)

- lobby 앞단 nginx/ingress 의 `proxy_buffering off` 및 `proxy_read_timeout` 확대. 배포 호스트 설정이라 이 저장소에 없다. heartbeat 이 idle timeout 은 막지만 버퍼링 자체는 프록시 설정이 있어야 완전히 해소된다.
- WordOnlineClient: `MatchEventStream.Connect()` WebGL 분기가 fetch 성공 확인 전에 `IsConnected = true` 로 둔다. 스트림이 조용히 죽으면 15초 폴백 폴링이 시작되지 않는다.