### PR TITLE
Standardize lobby server version management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,3 +86,12 @@ Redis settings, and account server URLs must remain environment-driven.
 Database schema, seed, and operational data changes belong in
 `WordOnlineDatabase`. Do not add production SQL to this repository's runtime
 resources. Test-only fixtures may remain with their tests.
+
+## Versioning
+
+`version` in `build.gradle` is the lobby server's single version source. Update
+it in every runtime-behavior change: PATCH for backward-compatible fixes and
+internal changes, MINOR for backward-compatible features, and MAJOR for
+breaking API or protocol changes. Do not bump for documentation, tests, or
+agent-instruction-only changes. Never add a second runtime version or use a
+`-SNAPSHOT` deployable version. Spring Boot build info embeds this value.

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.wordonline'
-version = '0.0.1-SNAPSHOT'
+version = '0.0.2'
 description = 'word-online-matching'
 
 java {
@@ -18,6 +18,10 @@ java {
 
 jar {
     enabled = false
+}
+
+springBoot {
+    buildInfo()
 }
 
 apply plugin: 'kotlin-spring'


### PR DESCRIPTION
Closes #105

## What changed

- Set release version to `0.0.2`
- Removed the `SNAPSHOT` suffix
- Embedded Gradle version through Spring Boot build info
- Documented Semantic Versioning rules

## Why

Deployments need a stable, artifact-embedded version with one source of truth.

## Validation

- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./gradlew bootBuildInfo`
- Generated `build.version=0.0.2`
