### PR TITLE
feat(server): order aggregated rooms oldest first

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.wordonline'
-version = '0.0.2'
+version = '0.1.0'
 description = 'word-online-matching'
 
 java {

--- a/src/main/java/com/wordonline/matching/server/dto/RoomInfoDto.java
+++ b/src/main/java/com/wordonline/matching/server/dto/RoomInfoDto.java
@@ -1,10 +1,13 @@
 package com.wordonline.matching.server.dto;
 
+import java.time.Instant;
+
 public record RoomInfoDto(
         String sessionId,
         Long leftUserId,
         Long rightUserId,
-        String serverUrl
+        String serverUrl,
+        Instant createdAt
 ) {
 
 }

--- a/src/main/java/com/wordonline/matching/server/service/GameSessionService.java
+++ b/src/main/java/com/wordonline/matching/server/service/GameSessionService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Slf4j
@@ -29,8 +30,14 @@ public class GameSessionService {
                 .flatMap(this::fetchGameSessionsFromServer)
                 .collectList()
                 .map(listOfLists -> {
+                    // Each game server returns its own rooms oldest first, but flatMap interleaves the
+                    // servers non-deterministically, so the merged list has to be re-sorted or the same
+                    // set of rooms comes back in a different order on every request.
                     List<RoomInfoDto> allRooms = listOfLists.stream()
                             .flatMap(List::stream)
+                            .sorted(Comparator.comparing(RoomInfoDto::createdAt,
+                                            Comparator.nullsLast(Comparator.naturalOrder()))
+                                    .thenComparing(RoomInfoDto::sessionId))
                             .toList();
                     return new RoomListDto(allRooms);
                 });
@@ -48,7 +55,8 @@ public class GameSessionService {
                                     room.sessionId(),
                                     room.leftUserId(),
                                     room.rightUserId(),
-                                    serverUrl
+                                    serverUrl,
+                                    room.createdAt()
                             ))
                             .toList();
                 });


### PR DESCRIPTION
## 왜

`GameSessionService.getAllGameSessions()` 가 `findAllByTypeAndState(...).flatMap(...)` 로 게임 서버들을 훑는데, 리액티브 `flatMap` 은 순서를 보장하지 않는다. 같은 방 집합인데도 요청마다 순서가 달라져서 admin 방 목록의 "위쪽 방"이 의미를 갖지 못했다.

## 무엇을

- `RoomInfoDto` 에 `createdAt` 추가하고 게임 서버가 준 값을 그대로 전달.
- 병합된 목록을 `createdAt` 오름차순(동률이면 `sessionId`)으로 정렬. `createdAt` 이 없는 구버전 게임 서버 응답은 `nullsLast` 로 뒤에 붙는다.

게임 서버 쪽 `createdAt` 노출은 WordOnlineServer `feature/room-list-stable-order` 에서 같이 나간다. 그쪽이 먼저 배포되지 않아도 `null` 로 들어와 정렬만 무의미해질 뿐 깨지지 않는다.

## 테스트

`./gradlew test` 기준 `DataControllerTest` 2건, `CardControllerTest` 1건이 실패하는데, 깨끗한 `origin/main` 에서도 동일하게 실패한다 (`NumberFormatException` / `ConversionFailedException`). 이 PR 과 무관한 기존 실패라 손대지 않았다.

관련 PR: 게임 서버 `feature/room-list-stable-order`, 클라이언트 `feature/admin-room-list-tools`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)