### PR TITLE
feat: 초보 플레이어의 프랙티스 매칭을 접대 봇으로 보낸다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.wordonline'
-version = '0.1.0'
+version = '0.2.0'
 description = 'word-online-matching'
 
 java {

--- a/src/main/java/com/wordonline/matching/auth/domain/User.java
+++ b/src/main/java/com/wordonline/matching/auth/domain/User.java
@@ -20,9 +20,10 @@ public class User {
     private Long selectedDeckId;
     private Integer totalWins;
     private Long mmr;
-    // Set by the database default on insert, cleared by the game server once the player has met
-    // the tutorial opponent. Read here so the lobby can route their practice match.
-    private Boolean isNovice;
+    // How far the player is through the tutorial, from 0.5 to 1.0. Set by the database default on
+    // insert and raised by the game server on each win against the tutorial opponent. Read here so
+    // the lobby can route their practice match.
+    private Float noviceProgress;
 
     public User(long memberId) {
         this(memberId, UserStatus.Online, null, 0, null, null);

--- a/src/main/java/com/wordonline/matching/auth/domain/User.java
+++ b/src/main/java/com/wordonline/matching/auth/domain/User.java
@@ -20,8 +20,11 @@ public class User {
     private Long selectedDeckId;
     private Integer totalWins;
     private Long mmr;
+    // Set by the database default on insert, cleared by the game server once the player has met
+    // the tutorial opponent. Read here so the lobby can route their practice match.
+    private Boolean isNovice;
 
     public User(long memberId) {
-        this(memberId, UserStatus.Online, null, 0, null);
+        this(memberId, UserStatus.Online, null, 0, null, null);
     }
 }

--- a/src/main/java/com/wordonline/matching/auth/repository/UserRepository.java
+++ b/src/main/java/com/wordonline/matching/auth/repository/UserRepository.java
@@ -12,6 +12,13 @@ import reactor.core.publisher.Mono;
 public interface UserRepository extends R2dbcRepository<User, Long> {
 
     @Query("""
+SELECT is_novice
+FROM users
+WHERE id = :userId;
+""")
+    Mono<Boolean> isNovice(@Param("userId") Long userId);
+
+    @Query("""
 UPDATE users
 SET selected_deck_id = :deckId
 WHERE id = :userId;

--- a/src/main/java/com/wordonline/matching/auth/repository/UserRepository.java
+++ b/src/main/java/com/wordonline/matching/auth/repository/UserRepository.java
@@ -12,13 +12,6 @@ import reactor.core.publisher.Mono;
 public interface UserRepository extends R2dbcRepository<User, Long> {
 
     @Query("""
-SELECT is_novice
-FROM users
-WHERE id = :userId;
-""")
-    Mono<Boolean> isNovice(@Param("userId") Long userId);
-
-    @Query("""
 UPDATE users
 SET selected_deck_id = :deckId
 WHERE id = :userId;

--- a/src/main/java/com/wordonline/matching/auth/service/UserService.java
+++ b/src/main/java/com/wordonline/matching/auth/service/UserService.java
@@ -113,16 +113,16 @@ public class UserService {
     }
 
     /**
-     * Whether this player still has the novice mark, which routes their practice match to the
-     * tutorial opponent. Missing rows and bots answer false: only a real account that has not
-     * finished the tutorial gets that opponent.
+     * Whether this player is still working through the tutorial, which routes their practice match
+     * to the opponent that holds back. Reaching 1.0 means nothing is held back any more, so it is
+     * the same thing as having finished. Missing rows and bots answer false.
      */
     public Mono<Boolean> isNovice(Long userId) {
         if (userId == null || userId < 0) {
             return Mono.just(false);
         }
         return findUserDomain(userId)
-                .map(user -> Boolean.TRUE.equals(user.getIsNovice()))
+                .map(user -> user.getNoviceProgress() != null && user.getNoviceProgress() < 1.0f)
                 // Failing closed keeps the player queueing - they meet an ordinary bot and keep the
                 // mark for next time - but it must not be silent, or a novice who never meets the
                 // tutorial opponent looks like a routing bug rather than a lookup that failed.

--- a/src/main/java/com/wordonline/matching/auth/service/UserService.java
+++ b/src/main/java/com/wordonline/matching/auth/service/UserService.java
@@ -121,7 +121,13 @@ public class UserService {
         if (userId == null || userId < 0) {
             return Mono.just(false);
         }
-        return userRepository.isNovice(userId).defaultIfEmpty(false);
+        return findUserDomain(userId)
+                .map(user -> Boolean.TRUE.equals(user.getIsNovice()))
+                // Failing closed keeps the player queueing - they meet an ordinary bot and keep the
+                // mark for next time - but it must not be silent, or a novice who never meets the
+                // tutorial opponent looks like a routing bug rather than a lookup that failed.
+                .doOnError(error -> log.warn("Novice lookup failed for userId={}; treating as not a novice", userId, error))
+                .onErrorReturn(false);
     }
 
     @Transactional(propagation = Propagation.NOT_SUPPORTED)

--- a/src/main/java/com/wordonline/matching/auth/service/UserService.java
+++ b/src/main/java/com/wordonline/matching/auth/service/UserService.java
@@ -112,6 +112,18 @@ public class UserService {
                 .map(user -> user.getMmr() != null ? user.getMmr() : 0L);
     }
 
+    /**
+     * Whether this player still has the novice mark, which routes their practice match to the
+     * tutorial opponent. Missing rows and bots answer false: only a real account that has not
+     * finished the tutorial gets that opponent.
+     */
+    public Mono<Boolean> isNovice(Long userId) {
+        if (userId == null || userId < 0) {
+            return Mono.just(false);
+        }
+        return userRepository.isNovice(userId).defaultIfEmpty(false);
+    }
+
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public Mono<UserStatus> getStatus(Long userId) {
         if (userId == null || userId < 0){

--- a/src/main/kotlin/com/wordonline/matching/matching/domain/BotPersona.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/domain/BotPersona.kt
@@ -9,4 +9,7 @@ data class BotPersona(
     @Id @Column("user_id") val userId: Long,
     val name: String,
     val enabled: Boolean,
+    // The tutorial opponent. Enabled like any other bot -- it plays real sessions -- but reachable
+    // only through the novice path, never through the random practice pool.
+    val hospitality: Boolean = false,
 )

--- a/src/main/kotlin/com/wordonline/matching/matching/repository/BotPersonaRepository.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/repository/BotPersonaRepository.kt
@@ -8,14 +8,30 @@ import reactor.core.publisher.Mono
 interface BotPersonaRepository : R2dbcRepository<BotPersona, Long> {
     fun findByUserId(userId: Long): Mono<BotPersona>
 
+    // Excludes the hospitality bot on purpose. It is enabled, so without this clause an ordinary
+    // player would occasionally draw the opponent that is built to lose, which is not a practice
+    // match at all.
     @Query(
         """
-        SELECT user_id, name, enabled
+        SELECT user_id, name, enabled, hospitality
         FROM bot_personas
         WHERE enabled = TRUE
+          AND hospitality = FALSE
         ORDER BY RANDOM()
         LIMIT 1
         """
     )
     fun findRandomEnabled(): Mono<BotPersona>
+
+    @Query(
+        """
+        SELECT user_id, name, enabled, hospitality
+        FROM bot_personas
+        WHERE enabled = TRUE
+          AND hospitality = TRUE
+        ORDER BY user_id
+        LIMIT 1
+        """
+    )
+    fun findHospitality(): Mono<BotPersona>
 }

--- a/src/main/kotlin/com/wordonline/matching/matching/service/BotMemberMaker.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/service/BotMemberMaker.kt
@@ -15,6 +15,10 @@ class BotMemberMaker(
         .map(BotPersona::userId)
         .switchIfEmpty(Mono.error(IllegalStateException("No enabled bot persona is available.")))
 
+    fun getHospitalityBotId(): Mono<Long> = botPersonaRepository.findHospitality()
+        .map(BotPersona::userId)
+        .switchIfEmpty(Mono.error(IllegalStateException("No hospitality bot persona is available.")))
+
     fun getBot(botId: Long): Mono<AccountMemberResponseDto> {
         require(botId < 0) { "Bot user ID must be negative." }
 

--- a/src/main/kotlin/com/wordonline/matching/matching/service/GameMatchService.kt
+++ b/src/main/kotlin/com/wordonline/matching/matching/service/GameMatchService.kt
@@ -16,10 +16,10 @@ import com.wordonline.matching.session.service.LegacyGameMatchService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingleOrNull
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
@@ -47,9 +47,28 @@ class GameMatchService(
 
     suspend fun matchPractice(userId: Long): MatchedInfoDto {
         val sessionId = "bot-${matchingQueueRepository.nextSessionId().awaitSingle()}"
-        val botId = botMemberMaker.getRandomEnabledBotId().awaitSingle()
+        val botId = practiceOpponentFor(userId)
         val sessionDto = SessionDto.Practice(sessionId, userId, botId)
         return legacyGameMatchService.createSession(sessionDto).matchInfo
+    }
+
+    // A player who still carries the novice mark is finishing the tutorial, and meets the opponent
+    // built to lose. The fallback matters: the tutorial opponent being unavailable must not be the
+    // reason a new player cannot start a match at all, so they get an ordinary bot and keep the
+    // mark for next time.
+    private suspend fun practiceOpponentFor(userId: Long): Long {
+        if (!userService.isNovice(userId).awaitSingle()) {
+            return botMemberMaker.getRandomEnabledBotId().awaitSingle()
+        }
+
+        return try {
+            botMemberMaker.getHospitalityBotId().awaitSingle()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn("No hospitality bot available for novice userId={}; falling back to the bot pool", userId, e)
+            botMemberMaker.getRandomEnabledBotId().awaitSingle()
+        }
     }
 
     suspend fun matchBots(leftBotId: Long, rightBotId: Long): MatchedInfoDto {

--- a/src/test/java/com/wordonline/matching/matching/service/BotMemberMakerTest.java
+++ b/src/test/java/com/wordonline/matching/matching/service/BotMemberMakerTest.java
@@ -28,7 +28,7 @@ class BotMemberMakerTest {
     @Test
     void returnsNameFromEnabledPersona() {
         when(botPersonaRepository.findByUserId(-7L))
-                .thenReturn(Mono.just(new BotPersona(-7L, "database bot", true)));
+                .thenReturn(Mono.just(new BotPersona(-7L, "database bot", true, false)));
 
         StepVerifier.create(botMemberMaker.getBot(-7L))
                 .expectNextMatches(member -> member.getName().equals("database bot"))
@@ -48,7 +48,7 @@ class BotMemberMakerTest {
     @Test
     void rejectsDisabledPersona() {
         when(botPersonaRepository.findByUserId(-7L))
-                .thenReturn(Mono.just(new BotPersona(-7L, "disabled bot", false)));
+                .thenReturn(Mono.just(new BotPersona(-7L, "disabled bot", false, false)));
 
         StepVerifier.create(botMemberMaker.getBot(-7L))
                 .expectErrorMatches(error -> error instanceof IllegalStateException
@@ -59,11 +59,33 @@ class BotMemberMakerTest {
     @Test
     void selectsBotFromEnabledPersonaCatalog() {
         when(botPersonaRepository.findRandomEnabled())
-                .thenReturn(Mono.just(new BotPersona(-12L, "random bot", true)));
+                .thenReturn(Mono.just(new BotPersona(-12L, "random bot", true, false)));
 
         StepVerifier.create(botMemberMaker.getRandomEnabledBotId())
                 .expectNext(-12L)
                 .verifyComplete();
+    }
+
+    @Test
+    void selectsTheHospitalityPersonaForTheNovicePath() {
+        when(botPersonaRepository.findHospitality())
+                .thenReturn(Mono.just(new BotPersona(-3L, "Warm Welcome", true, true)));
+
+        StepVerifier.create(botMemberMaker.getHospitalityBotId())
+                .expectNext(-3L)
+                .verifyComplete();
+    }
+
+    // The caller falls back to the ordinary pool on this error. A missing tutorial opponent must not
+    // be the reason a new player cannot start a match.
+    @Test
+    void reportsWhenNoHospitalityPersonaExists() {
+        when(botPersonaRepository.findHospitality()).thenReturn(Mono.empty());
+
+        StepVerifier.create(botMemberMaker.getHospitalityBotId())
+                .expectErrorMatches(error -> error instanceof IllegalStateException
+                        && error.getMessage().contains("No hospitality bot persona"))
+                .verify();
     }
 
     @Test


### PR DESCRIPTION
Closes #109

## 베이스를 main으로 잡은 이유

열린 PR 위에 쌓으려 했으나 세 개(#77 `fix/68`, #76 `fix/67`, #75 `fix/62`) **모두 main보다 39커밋 뒤처져 있다.** 각자 커밋은 1개씩이다. 그 위에 쌓으면 낡은 트리를 물려받고, `build.gradle`도 main이 `0.1.0`으로 고쳐 놓은 걸 `0.0.1-SNAPSHOT`으로 되돌리게 된다 — 루트 `AGENTS.md`가 배포 컴포넌트에 금지한 값이다.

## 변경

- `User.noviceProgress` — `users.novice_progress`(0.5~1.0)를 엔티티로 읽는다
- `UserService.isNovice` — 진행도가 1.0 미만이면 초보. 1.0은 접대 봇이 전혀 봐주지 않는다는 뜻이고 그건 곧 튜토리얼을 끝냈다는 뜻이라, 별도 졸업 플래그가 없다. 행이 없거나 봇이면 false
- `BotPersonaRepository.findRandomEnabled` — **`hospitality = FALSE` 조건 추가.** 접대 봇은 `enabled`이고 실제 세션을 뛰기 때문에, 이 조건이 없으면 일반 플레이어가 이따금 "이기려 하지 않는 상대"를 뽑는다. 그건 연습 경기가 아니다
- `findHospitality` / `BotMemberMaker.getHospitalityBotId` 추가
- `GameMatchService.practiceOpponentFor` — 초보면 접대 봇, 아니면 기존 풀

**폴백이 중요하다.** 접대 봇 조회가 실패하면 일반 봇으로 떨어지고 진행도는 그대로 남는다. 튜토리얼 상대가 없다는 게 신규 유저가 매치를 아예 시작 못 하는 이유가 되면 안 된다. `CancellationException`은 다시 던진다.

## 실행해서 잡은 버그 하나

처음에는 `@Query`로 스칼라 값을 읽었는데 실제 데이터베이스에서 깨졌다.

```
MappingException: Expected to read Document RowDocument{is_novice=false}
into type class java.lang.Boolean but didn't find a PersistentEntity
```

Spring Data R2DBC는 저장소의 도메인 타입으로 매핑하므로, 단일 컬럼 프로젝션을 `Boolean`으로 받을 대상이 없다. **테스트 스위트에는 이 경로를 덮는 것이 없었고 로컬에 띄워 봐야 드러났다.** 컬럼을 `User`에 두어 기존 매핑을 타게 고쳤다.

조회 실패는 `log.warn`으로 남긴다. 닫히는 방향(초보가 아닌 것으로 취급)이라 매칭은 계속되지만, 조용하면 "초보인데 튜토리얼 상대를 못 만난다"가 배정 버그처럼 보인다.

## 검증

`./gradlew test` — `BotMemberMakerTest` 통과 (접대 봇 선택, 부재 시 에러 두 케이스 추가).

**선재 실패 3건이 있다.** `DataControllerTest` 2건, `CardControllerTest` 1건. 이 브랜치 변경 없이 깨끗한 `origin/main`에서 돌려도 똑같이 실패한다 — 이 PR과 무관하다.

로컬에 게임 서버와 함께 띄워 확인했다: 진행도 0.5인 유저는 접대 봇으로, 1.0인 유저는 일반 풀로(8회 연속 추첨에서 접대 봇 미출현), 신규 생성 유저는 기본값 0.5로 접대 봇에 배정.

## 선행

데이터베이스 저장소의 `users.novice_progress`, `bot_personas.hospitality` 마이그레이션(#67)이 먼저 배포되어야 한다.

## 버전

`0.1.0` → `0.2.0` (MINOR)