### PR TITLE
AGENTS.md: 버전은 PR마다가 아니라 deploy 때 올린다

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,9 +89,13 @@ resources. Test-only fixtures may remain with their tests.
 
 ## Versioning
 
-`version` in `build.gradle` is the lobby server's single version source. Update
-it in every runtime-behavior change: PATCH for backward-compatible fixes and
-internal changes, MINOR for backward-compatible features, and MAJOR for
-breaking API or protocol changes. Do not bump for documentation, tests, or
-agent-instruction-only changes. Never add a second runtime version or use a
-`-SNAPSHOT` deployable version. Spring Boot build info embeds this value.
+`version` in `build.gradle` is the lobby server's single version source.
+Do not bump it in a pull request. The monorepo `deploy` skill bumps it once per
+promotion: it commits `chore(release): WordOnlineMatching vX.Y.Z` to `main`, merges
+`main` into `deploy`, then tags and releases `vX.Y.Z` on the merge commit. The level comes
+from the Conventional Commit messages promoted in that release: MAJOR for a `!`
+marker or a `BREAKING CHANGE` trailer, MINOR for `feat:`, PATCH otherwise, so
+write accurate commit types.
+
+Never add a second runtime version or use a `-SNAPSHOT` deployable version.
+Spring Boot build info embeds this value.


### PR DESCRIPTION
## 요약

`AGENTS.md`의 Versioning 섹션을 새 규칙으로 교체한다. 기능 PR에서는 버전을 올리지 않는다.

모노레포 `deploy` 스킬이 릴리스마다 한 번:

1. `main`에 `chore(release): WordOnlineMatching vX.Y.Z` 커밋을 올린다.
2. `main`을 `deploy`로 머지한다.
3. 그 머지 커밋에 `vX.Y.Z` 태그와 릴리스를 만든다.

레벨은 그 릴리스에 들어간 Conventional Commit 메시지에서 뽑는다: `!` 마커나 `BREAKING CHANGE` 트레일러면 MAJOR, `feat:`면 MINOR, 나머지는 PATCH.

## 이유

PR마다 버전을 올리니 같은 버전 라인에서 계속 충돌이 났다.

## 테스트

문서만 바뀐다. 런타임 변경 없음.

Closes #111