### PR TITLE
chore: standardize repository line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
-/gradlew text eol=lf
+* text=auto eol=lf
+
+*.cmd text eol=crlf
 *.bat text eol=crlf
 *.jar binary


### PR DESCRIPTION
## Summary

- enforce LF for automatically detected text files
- retain CRLF checkout behavior for Windows `.cmd` and `.bat` scripts
- preserve binary handling for JAR files
- renormalized tracked files: 0; existing tracked text already used compliant repository line endings

## Validation

- `git add --renormalize .`
- prescribed tracked CRLF scan reports only `gradlew.bat`, an allowed exception
- `git diff --cached -w --stat`
- `git diff --check`

Closes #113